### PR TITLE
Turn-based card draw/discard + show Black ATK multiplier in HUD

### DIFF
--- a/Scripts/StatsHUD.gd
+++ b/Scripts/StatsHUD.gd
@@ -48,12 +48,13 @@ func _refresh() -> void:
 
 	var rs: RunState = _round.run_state
 	if rs != null:
+		var black_mult: int = _black_attack_multiplier()
 		if round_label != null:
 			round_label.text = "Round: %d" % (rs.round_index + 1)
 		if player_hp_label != null:
 			player_hp_label.text = "Player HP: %d/%d" % [rs.player_hp, rs.player_max_hp]
 		if enemy_hp_label != null:
-			enemy_hp_label.text = "Enemy HP: %d/%d" % [rs.enemy_hp, rs.enemy_max_hp]
+			enemy_hp_label.text = "Enemy HP: %d/%d  ATK x%d" % [rs.enemy_hp, rs.enemy_max_hp, black_mult]
 		if gold_label != null:
 			gold_label.text = "Gold: %d" % rs.gold
 	else:
@@ -139,3 +140,10 @@ func _pips_remaining_for(s: BoardState, player: int) -> int:
 			total += 25
 
 	return total
+
+func _black_attack_multiplier() -> int:
+	if _round == null:
+		return 1
+	if _round.ai == null or _round.ai.advantage == null:
+		return 1
+	return maxi(1, int(_round.ai.advantage.damage_multiplier(_round.black_turn_index)))


### PR DESCRIPTION
### Motivation
- Show the enemy (Black) attack multiplier in the HUD so the AI's increasing damage is visible next to enemy HP.
- Implement proper turn-based card drawing so new cards are drawn from a deck into empty hand slots at the start of White's turns.
- Preserve card usage semantics by moving used cards to a discard pile and reshuffling the discard into the draw pile when needed.

### Description
- Update `Scripts/StatsHUD.gd` to display `ATK xN` next to the enemy HP and add `func _black_attack_multiplier()` which reads `_round.ai.advantage.damage_multiplier(_round.black_turn_index)` with a fallback of `1`.
- Add `draw_pile` and `discard_pile` arrays to `Scripts/game/RoundController.gd` and wire them into round start and turn logic.
- On round start (`start_round`) clear the hand, call `_reset_card_piles()` to populate and shuffle the draw pile from `run_state.deck`, and call `_draw_cards_into_hand(hand_size)` to fill the hand.
- On each new White turn draw into empty hand slots via `_draw_cards_into_hand(hand_size - hand.size())`; consume events now append the consumed card ID into `discard_pile`, and `_draw_cards_into_hand` reshuffles `discard_pile` into `draw_pile` when `draw_pile` is empty.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969532f7258832e953ad20b917c5d76)