### PR TITLE
Stabilize hand slots and draw into empty slots to remove flicker

### DIFF
--- a/Scripts/HandHUD.gd
+++ b/Scripts/HandHUD.gd
@@ -37,12 +37,14 @@ func _on_hand_changed(hand: Array[CardInstance]) -> void:
 	for child in card_list.get_children():
 		child.queue_free()
 
-	# Build buttons for current hand
+	# Build buttons for current hand (preserve empty slots)
 	for ci in hand:
-		if ci == null or ci.def == null:
-			continue
 		var btn := card_button_scene.instantiate() as CardSlotButton
 		card_list.add_child(btn)
+		if ci == null or ci.def == null:
+			btn.self_player = self_player
+			btn.clear_card()
+			continue
 		btn.setup(round, ci, self_player)
 
 func _find_round_controller() -> RoundController:


### PR DESCRIPTION
### Motivation
- Fix visible flicker when drawing cards by preventing transient removal/reordering of hand entries so only the newly drawn card appears. 
- Prevent cards from shifting up when a preceding slot is consumed so card positions remain visually stable.

### Description
- Keep the `hand` array at a fixed size and add helpers `_ensure_hand_slots` and `_count_empty_hand_slots` to manage empty slots in `Scripts/game/RoundController.gd`.
- Change `_draw_cards_into_hand` to fill `null` slots instead of appending, and call it with `_count_empty_hand_slots()` from `start_round` and `start_turn` so new cards populate gaps.
- Mark consumed cards as `null` in `_on_card_consumed_internal` instead of `remove_at` and update debug helpers (`debug_clear_hand`, `debug_fill_hand`, `debug_set_hand_index`, `debug_remove_hand_index`, `debug_append_card`) to preserve slot layout.
- Render empty slots in the HUD by instantiating a `CardSlotButton` for each hand slot and calling `btn.clear_card()` for `null` entries in `Scripts/HandHUD.gd` so visual positions remain constant.
- Files changed: `Scripts/game/RoundController.gd`, `Scripts/HandHUD.gd`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696957db6ef0832e8b7a651bca07e065)