### PR TITLE
Apply damage when black is stuck on the bar

### DIFF
--- a/Scripts/game/RoundController.gd
+++ b/Scripts/game/RoundController.gd
@@ -492,12 +492,22 @@ func _start_black_ai_turn() -> void:
 
 	# If truly no moves, pass.
 	if _count_legal_moves_black_ai() == 0:
+		_apply_black_bar_stuck_damage()
 		_ai_running = false
 		end_turn()
 		_set_input_enabled(true)
 		return
 
 	call_deferred("_black_ai_play")
+
+func _apply_black_bar_stuck_damage() -> void:
+	if run_state == null or state == null:
+		return
+	var bar_count: int = int(state.bar_black.size())
+	if bar_count <= 0:
+		return
+	run_state.enemy_hp = maxi(0, int(run_state.enemy_hp) - bar_count)
+	show_notice("Enemy takes %d damage from stranded bar checkers." % bar_count)
 
 
 func _count_legal_moves_black_ai() -> int:


### PR DESCRIPTION
### Motivation
- Ensure the game penalizes the enemy HP when the BLACK AI has checkers stranded on the bar and cannot make any legal moves, by applying damage equal to the number of stranded checkers.

### Description
- Call ` _apply_black_bar_stuck_damage()` from `_start_black_ai_turn()` when `_count_legal_moves_black_ai() == 0` to apply the penalty before passing the turn.
- Add `func _apply_black_bar_stuck_damage()` which checks `run_state` and `state`, computes `bar_count = state.bar_black.size()`, subtracts that amount from `run_state.enemy_hp` (clamped with `maxi(0, ...)`), and emits a notice via `show_notice()`.
- The new code is placed in `Scripts/game/RoundController.gd` and includes guards so nothing happens if there is no `run_state`, no `state`, or the bar is empty.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696958018248832e894241c09eac2059)