### PR TITLE
Use full card catalog for starting deck

### DIFF
--- a/Scripts/RunController.gd
+++ b/Scripts/RunController.gd
@@ -50,12 +50,12 @@ func _start_new_run() -> void:
 	# placeholder deck container (safe if RunState already defines it)
 	if "deck" in run_state:
 		run_state.deck.clear()
-	# Starter deck (MVP)
-	if run_state.deck.is_empty():
-		var starter := ["ionic_crossbow", "one_man_army", "mortar", "subterfuge","sniper","depth_charge", "double_down"]
-		for id in starter:
-			if CardDB.get_def(id) != null:
-				run_state.deck.append(id)
+	# Use the entire available card catalog for the starting deck.
+	var available_ids := CardDB.all_ids()
+	if available_ids.is_empty():
+		push_warning("[RunController] No card IDs found in CardDB; starting deck is empty.")
+	else:
+		run_state.deck = available_ids
 
 
 func _start_current_round() -> void:


### PR DESCRIPTION
### Motivation
- Replace the small hardcoded starter deck so the full set of available cards can be drawn at the start of a run instead of a select subset.

### Description
- In `Scripts/RunController.gd` replace the previous `starter` array logic with `CardDB.all_ids()` to seed `run_state.deck`, and emit `push_warning` if the catalog returns empty.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696973a7621c832ea5149d7eb3de02a0)