### PR TITLE
Add Stopgap, Respite and Zero Sum defense cards and mechanics

### DIFF
--- a/Resources/cards/card_catalog.tres
+++ b/Resources/cards/card_catalog.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="CardCatalog" load_steps=18 format=3 uid="uid://5o2fjm0okvs0"]
+[gd_resource type="Resource" script_class="CardCatalog" load_steps=21 format=3 uid="uid://5o2fjm0okvs0"]
 
 [ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="1_gfijg"]
 [ext_resource type="Script" uid="uid://cxrrf2trr2miv" path="res://CardCatalog.gd" id="2_k16gf"]
@@ -17,8 +17,11 @@
 [ext_resource type="Resource" uid="uid://ol4tlv1smpvwz" path="res://Resources/cards/defense/bunker.tres" id="14_defense_bunker"]
 [ext_resource type="Resource" uid="uid://k6s1agvv15ter" path="res://Resources/cards/defense/tunnel.tres" id="15_defense_tunnel"]
 [ext_resource type="Resource" uid="uid://7peow9kpvxt56" path="res://Resources/cards/defense/no_mans_land.tres" id="16_defense_no_mans_land"]
+[ext_resource type="Resource" uid="uid://d7m5c4o2b70gk" path="res://Resources/cards/defense/stopgap.tres" id="17_defense_stopgap"]
+[ext_resource type="Resource" uid="uid://b1xfrb5idbbdq" path="res://Resources/cards/defense/respite.tres" id="18_defense_respite"]
+[ext_resource type="Resource" uid="uid://dyy7rtn7v70ja" path="res://Resources/cards/defense/zero_sum.tres" id="19_defense_zero_sum"]
 
 [resource]
 script = ExtResource("2_k16gf")
-cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land")])
+cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum")])
 metadata/_custom_type_script = "uid://cxrrf2trr2miv"

--- a/Resources/cards/defense/respite.tres
+++ b/Resources/cards/defense/respite.tres
@@ -1,0 +1,33 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://b1xfrb5idbbdq"]
+
+[ext_resource type="Texture2D" uid="uid://cnhhcd6r4kld6" path="res://Assets/textures/cards/red deck fronts/2 plus red.jpg" id="1_respite"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_respite"]
+[ext_resource type="Script" uid="uid://d4lb1e7m2x7ar" path="res://Scripts/cards/effects/EffectRespite.gd" id="3_respite"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_respite"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_respite"]
+
+[sub_resource type="Resource" id="Resource_respite_effect"]
+script = ExtResource("3_respite")
+metadata/_custom_type_script = "uid://d4lb1e7m2x7ar"
+
+[sub_resource type="Resource" id="Resource_respite_pattern"]
+script = ExtResource("4_respite")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 0, 0, 0)
+mix_mins = PackedInt32Array(2, 1, 1, 2)
+mix_maxs = PackedInt32Array(15, 1, 1, 15)
+mix_requires_empty = PackedInt32Array(0, 0, 0, 0)
+mix_same_half_only = true
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_respite")
+id = "respite"
+title = "Respite"
+category = 3
+pip_value = 2
+pattern = Array[ExtResource("4_respite")]([SubResource("Resource_respite_pattern")])
+effect = SubResource("Resource_respite_effect")
+art_texture = ExtResource("1_respite")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/defense/stopgap.tres
+++ b/Resources/cards/defense/stopgap.tres
@@ -1,0 +1,34 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://d7m5c4o2b70gk"]
+
+[ext_resource type="Texture2D" uid="uid://wpr8s716j2eu" path="res://Assets/textures/cards/red deck fronts/3 plus red.jpg" id="1_stopgap"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_stopgap"]
+[ext_resource type="Script" uid="uid://c0sdvl65g23p3" path="res://Scripts/cards/effects/EffectStopgap.gd" id="3_stopgap"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_stopgap"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_stopgap"]
+
+[sub_resource type="Resource" id="Resource_stopgap_effect"]
+script = ExtResource("3_stopgap")
+metadata/_custom_type_script = "uid://c0sdvl65g23p3"
+
+[sub_resource type="Resource" id="Resource_stopgap_pattern"]
+script = ExtResource("4_stopgap")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 0, 1)
+mix_mins = PackedInt32Array(1, 0, 1)
+mix_maxs = PackedInt32Array(1, 0, 1)
+mix_requires_empty = PackedInt32Array(0, 1, 0)
+mix_allow_reverse = true
+mix_same_half_only = false
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_stopgap")
+id = "stopgap"
+title = "Stopgap"
+category = 3
+pip_value = 3
+pattern = Array[ExtResource("4_stopgap")]([SubResource("Resource_stopgap_pattern")])
+effect = SubResource("Resource_stopgap_effect")
+art_texture = ExtResource("1_stopgap")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/defense/zero_sum.tres
+++ b/Resources/cards/defense/zero_sum.tres
@@ -1,0 +1,38 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://dyy7rtn7v70ja"]
+
+[ext_resource type="Texture2D" uid="uid://cgyldsqwys86c" path="res://Assets/textures/cards/red deck fronts/1 plus red.jpg" id="1_zero_sum"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_zero_sum"]
+[ext_resource type="Script" uid="uid://s3yy4cl3qf1da" path="res://Scripts/cards/effects/EffectZeroSum.gd" id="3_zero_sum"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_zero_sum"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_zero_sum"]
+
+[sub_resource type="Resource" id="Resource_zero_sum_effect"]
+script = ExtResource("3_zero_sum")
+metadata/_custom_type_script = "uid://s3yy4cl3qf1da"
+
+[sub_resource type="Resource" id="Resource_zero_sum_pattern"]
+script = ExtResource("4_zero_sum")
+kind = 1
+owner_a = 0
+owner_b = 1
+min_count_a = 3
+max_count_a = 15
+min_count_b = 3
+max_count_b = 15
+adj_either_order = true
+seq_counts = null
+mix_owners = null
+mix_mins = null
+mix_maxs = null
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_zero_sum")
+id = "zero_sum"
+title = "Zero Sum"
+category = 3
+pip_value = 1
+pattern = Array[ExtResource("4_zero_sum")]([SubResource("Resource_zero_sum_pattern")])
+effect = SubResource("Resource_zero_sum_effect")
+art_texture = ExtResource("1_zero_sum")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Scenes/board/BoardView.tscn
+++ b/Scenes/board/BoardView.tscn
@@ -357,6 +357,8 @@ highlight_scale = 0.2
 
 [node name="NoMansLandLayer" type="Node2D" parent="."]
 
+[node name="StopgapLayer" type="Node2D" parent="."]
+
 [node name="BarClickWhite" type="Area2D" parent="."]
 position = Vector2(644.6667, 70)
 

--- a/Scripts/ai/BackgammonBoardAdapter.gd
+++ b/Scripts/ai/BackgammonBoardAdapter.gd
@@ -16,7 +16,7 @@ func legal_moves_for_die(die: int, player: int) -> Array:
 	return Rules.legal_moves_for_die_adv(state, player, int(die), bearoff_home_fraction)
 
 func apply_move(move: Dictionary, player: int) -> void:
-	Rules.apply_move(state, player, move)
+	Rules.apply_move_with_zero_sum(state, player, move)
 
 func features() -> Dictionary:
 	var f: Dictionary = {}

--- a/Scripts/cards/effects/EffectEngulf.gd
+++ b/Scripts/cards/effects/EffectEngulf.gd
@@ -34,8 +34,12 @@ func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> v
 		var mid_id: int = int(mid_stack[0])
 		hit_black = round.state.owner_of(mid_id) == BoardState.Player.BLACK
 
-	Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": left_pt, "to": mid_pt, "hit": hit_black})
-	Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": right_pt, "to": mid_pt, "hit": false})
+	if round.has_method("apply_move_with_zero_sum"):
+		round.call("apply_move_with_zero_sum", {"from": left_pt, "to": mid_pt, "hit": hit_black}, BoardState.Player.WHITE)
+		round.call("apply_move_with_zero_sum", {"from": right_pt, "to": mid_pt, "hit": false}, BoardState.Player.WHITE)
+	else:
+		Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": left_pt, "to": mid_pt, "hit": hit_black})
+		Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": right_pt, "to": mid_pt, "hit": false})
 
 	if round.run_state != null:
 		round.deal_enemy_damage(enemy_damage)

--- a/Scripts/cards/effects/EffectFlanked.gd
+++ b/Scripts/cards/effects/EffectFlanked.gd
@@ -54,7 +54,10 @@ func _handle_black_stack(round: RoundController, black_pt: int, white_adjacent: 
 		Rules.send_checker_to_bar(round.state, hit_id)
 		var white_stack: PackedInt32Array = round.state.points[white_adjacent]
 		if not white_stack.is_empty():
-			Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": white_adjacent, "to": black_pt, "hit": false})
+			if round.has_method("apply_move_with_zero_sum"):
+				round.call("apply_move_with_zero_sum", {"from": white_adjacent, "to": black_pt, "hit": false}, BoardState.Player.WHITE)
+			else:
+				Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": white_adjacent, "to": black_pt, "hit": false})
 		return
 
 	var top_id: int = int(black_stack[black_stack.size() - 1])

--- a/Scripts/cards/effects/EffectRespite.gd
+++ b/Scripts/cards/effects/EffectRespite.gd
@@ -1,0 +1,25 @@
+extends CardEffect
+class_name EffectRespite
+
+func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> void:
+	if round == null or round.state == null or card == null or card.def == null:
+		return
+
+	var req: PatternReq = null
+	for r: PatternReq in card.def.pattern:
+		if r != null and r.kind == PatternReq.Kind.RUN_SEQUENCE_MIXED:
+			req = r
+			break
+
+	if req == null:
+		push_warning("[EffectRespite] No RUN_SEQUENCE_MIXED PatternReq on card.")
+		return
+
+	var start_point: int = PatternMatcher.find_run_sequence_mixed_start(req, ctx)
+	if start_point == -1:
+		push_warning("[EffectRespite] Pattern ready but could not locate matched start.")
+		return
+
+	var points := PackedInt32Array([start_point, start_point + 1, start_point + 2, start_point + 3])
+	if round.has_method("activate_respite"):
+		round.call("activate_respite", points, card)

--- a/Scripts/cards/effects/EffectRespite.gd.uid
+++ b/Scripts/cards/effects/EffectRespite.gd.uid
@@ -1,0 +1,1 @@
+uid://d4lb1e7m2x7ar

--- a/Scripts/cards/effects/EffectStopgap.gd
+++ b/Scripts/cards/effects/EffectStopgap.gd
@@ -1,0 +1,25 @@
+extends CardEffect
+class_name EffectStopgap
+
+func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> void:
+	if round == null or round.state == null or card == null or card.def == null:
+		return
+
+	var req: PatternReq = null
+	for r: PatternReq in card.def.pattern:
+		if r != null and r.kind == PatternReq.Kind.RUN_SEQUENCE_MIXED:
+			req = r
+			break
+
+	if req == null:
+		push_warning("[EffectStopgap] No RUN_SEQUENCE_MIXED PatternReq on card.")
+		return
+
+	var start_point: int = PatternMatcher.find_run_sequence_mixed_start(req, ctx)
+	if start_point == -1:
+		push_warning("[EffectStopgap] Pattern ready but could not locate matched start.")
+		return
+
+	var gap_pt: int = start_point + 1
+	if round.has_method("activate_stopgap"):
+		round.call("activate_stopgap", gap_pt, card)

--- a/Scripts/cards/effects/EffectStopgap.gd.uid
+++ b/Scripts/cards/effects/EffectStopgap.gd.uid
@@ -1,0 +1,1 @@
+uid://c0sdvl65g23p3

--- a/Scripts/cards/effects/EffectSuperiority.gd
+++ b/Scripts/cards/effects/EffectSuperiority.gd
@@ -36,7 +36,10 @@ func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> v
 		var white_stack: PackedInt32Array = round.state.points[white_pt]
 		if white_stack.is_empty():
 			break
-		Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": white_pt, "to": black_pt, "hit": false})
+		if round.has_method("apply_move_with_zero_sum"):
+			round.call("apply_move_with_zero_sum", {"from": white_pt, "to": black_pt, "hit": false}, BoardState.Player.WHITE)
+		else:
+			Rules.apply_move(round.state, BoardState.Player.WHITE, {"from": white_pt, "to": black_pt, "hit": false})
 
 	if round.run_state != null:
 		round.deal_enemy_damage(enemy_damage)

--- a/Scripts/cards/effects/EffectZeroSum.gd
+++ b/Scripts/cards/effects/EffectZeroSum.gd
@@ -1,0 +1,65 @@
+extends CardEffect
+class_name EffectZeroSum
+
+func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> void:
+	if round == null or round.state == null or card == null or card.def == null:
+		return
+
+	var req: PatternReq = null
+	for r: PatternReq in card.def.pattern:
+		if r != null and r.kind == PatternReq.Kind.ADJACENT_PAIR:
+			req = r
+			break
+
+	if req == null:
+		push_warning("[EffectZeroSum] No ADJACENT_PAIR PatternReq on card.")
+		return
+
+	var points := _find_adjacent_pair(req, ctx)
+	if points.is_empty():
+		push_warning("[EffectZeroSum] Pattern ready but could not locate matched points.")
+		return
+
+	if round.has_method("activate_zero_sum"):
+		round.call("activate_zero_sum", points, card)
+
+func _find_adjacent_pair(req: PatternReq, ctx: PatternContext) -> PackedInt32Array:
+	for a in range(24):
+		for b in [a - 1, a + 1]:
+			if b < 0 or b > 23:
+				continue
+
+			if _point_matches_range(ctx, a, req.owner_a, req.min_count_a, req.max_count_a, req.require_empty_a) \
+			and _point_matches_range(ctx, b, req.owner_b, req.min_count_b, req.max_count_b, req.require_empty_b):
+				return PackedInt32Array([a, b])
+
+			if req.adj_either_order:
+				if _point_matches_range(ctx, a, req.owner_b, req.min_count_b, req.max_count_b, req.require_empty_b) \
+				and _point_matches_range(ctx, b, req.owner_a, req.min_count_a, req.max_count_a, req.require_empty_a):
+					return PackedInt32Array([a, b])
+
+	return PackedInt32Array()
+
+func _point_matches_range(
+	ctx: PatternContext,
+	point_i: int,
+	owner: int,
+	min_c: int,
+	max_c: int,
+	require_empty: bool
+) -> bool:
+	if point_i < 0 or point_i > 23:
+		return false
+
+	var st: PackedInt32Array = ctx.state.points[point_i]
+	var n: int = st.size()
+
+	if require_empty:
+		return n == 0
+	if n == 0:
+		return false
+
+	if ctx.state.owner_of(int(st[0])) != owner:
+		return false
+
+	return n >= min_c and n <= max_c

--- a/Scripts/cards/effects/EffectZeroSum.gd.uid
+++ b/Scripts/cards/effects/EffectZeroSum.gd.uid
@@ -1,0 +1,1 @@
+uid://s3yy4cl3qf1da

--- a/Scripts/view/board/BoardView.gd
+++ b/Scripts/view/board/BoardView.gd
@@ -15,8 +15,10 @@ signal bar_clicked(player: int)
 @onready var animator: BoardAnimator = $BoardAnimator
 @onready var highlights: BoardHighlights = $HighlightsLayer
 @onready var no_mans_land_layer: Node2D = get_node_or_null("NoMansLandLayer") as Node2D
+@onready var stopgap_layer: Node2D = get_node_or_null("StopgapLayer") as Node2D
 
 var _no_mans_land_labels: Dictionary = {}
+var _stopgap_labels: Dictionary = {}
 
 func show_move_targets(targets: Array[int], player: int) -> void:
 	var is_white: bool = (player == BoardState.Player.WHITE)
@@ -74,6 +76,33 @@ func set_no_mans_land_counts(counts: Dictionary) -> void:
 		label.position = pos + Vector2(-12, -10)
 		no_mans_land_layer.add_child(label)
 		_no_mans_land_labels[point] = label
+
+func set_stopgap_points(points: Array) -> void:
+	if stopgap_layer == null:
+		return
+
+	for key in _stopgap_labels.keys():
+		var label: Label = _stopgap_labels[key] as Label
+		if is_instance_valid(label):
+			label.queue_free()
+	_stopgap_labels.clear()
+
+	for entry in points:
+		var point: int = int(entry)
+		if point < 0 or point > 23:
+			continue
+
+		var label := Label.new()
+		label.text = "Stopgap"
+		label.scale = Vector2(0.7, 0.7)
+		label.z_index = 645
+
+		var pos := Vector2.ZERO
+		if pieces != null:
+			pos = stopgap_layer.to_local(pieces.point_slot_global(point, 0))
+		label.position = pos + Vector2(-18, -22)
+		stopgap_layer.add_child(label)
+		_stopgap_labels[point] = label
 
 func animate_move_persistent(state: BoardState, move: Dictionary, player: int, done: Callable) -> void:
 	input.set_enabled(false)

--- a/Scripts/view/board/CheckerSprite.gd
+++ b/Scripts/view/board/CheckerSprite.gd
@@ -12,6 +12,9 @@ signal clicked(checker_id: int)
 @onready var click_area: Area2D = get_node_or_null(click_area_path) as Area2D
 
 var checker_id: int = -1
+var _zero_sum_material: ShaderMaterial = null
+
+const ZERO_SUM_SHADER_PATH := "res://Shaders/zero_sum_overlay.gdshader"
 
 func _ready() -> void:
 	if click_area != null:
@@ -26,6 +29,27 @@ func set_color(is_white: bool) -> void:
 	if sprite == null:
 		return
 	sprite.texture = tex_white if is_white else tex_black
+
+func set_zero_sum_state(enabled: bool, overlay_color: Color) -> void:
+	if sprite == null:
+		return
+
+	if not enabled:
+		if sprite.material == _zero_sum_material:
+			sprite.material = null
+		_zero_sum_material = null
+		return
+
+	if _zero_sum_material == null:
+		var shader: Shader = load(ZERO_SUM_SHADER_PATH) as Shader
+		if shader == null:
+			push_warning("[CheckerSprite] Missing shader: %s" % ZERO_SUM_SHADER_PATH)
+			return
+		_zero_sum_material = ShaderMaterial.new()
+		_zero_sum_material.shader = shader
+
+	sprite.material = _zero_sum_material
+	_zero_sum_material.set_shader_parameter("overlay_color", overlay_color)
 
 func _on_click_area_input_event(_vp: Viewport, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:

--- a/Scripts/view/board/components/BoardPieces.gd
+++ b/Scripts/view/board/components/BoardPieces.gd
@@ -130,6 +130,16 @@ func _ensure_node(state: BoardState, id: int) -> void:
 		piece.call("set_color", is_white)
 	elif piece.has_method("set_color_animation"):
 		piece.call("set_color_animation", is_white)
+	_apply_zero_sum_visual(state, id, piece)
+
+func _apply_zero_sum_visual(state: BoardState, id: int, piece: Node2D) -> void:
+	if not piece.has_method("set_zero_sum_state"):
+		return
+	var info: CheckerInfo = state.checkers.get(id, null)
+	var zero_sum: bool = info != null and bool(info.tags.get("zero_sum", false))
+	var is_white: bool = (state.owner_of(id) == BoardState.Player.WHITE)
+	var color: Color = Color(0.2, 0.6, 1.0, 0.55) if is_white else Color(1.0, 0.2, 0.2, 0.55)
+	piece.call("set_zero_sum_state", zero_sum, color)
 
 
 func point_stack_dir_global(i: int) -> Vector2:

--- a/Shaders/zero_sum_overlay.gdshader
+++ b/Shaders/zero_sum_overlay.gdshader
@@ -1,0 +1,8 @@
+shader_type canvas_item;
+
+uniform vec4 overlay_color : source_color = vec4(0.2, 0.6, 1.0, 0.55);
+
+void fragment() {
+	vec4 tex = texture(TEXTURE, UV);
+	COLOR = mix(tex, overlay_color, overlay_color.a);
+}

--- a/Shaders/zero_sum_overlay.gdshader.uid
+++ b/Shaders/zero_sum_overlay.gdshader.uid
@@ -1,0 +1,1 @@
+uid://zx5ws0g6n2l0l


### PR DESCRIPTION
### Motivation
- Introduce three new defense cards (Stopgap, Respite, Zero Sum) and implement their in-game mechanics so patterns on the board can activate persistent effects and special hit interactions. 
- Integrate the new mechanics into the game rule engine, AI simulations, and board visuals so gameplay, AI decision-making, and UI all reflect the new card behaviors.

### Description
- Added card resources and effect scripts for the new cards: `Resources/cards/defense/stopgap.tres`, `respite.tres`, `zero_sum.tres` and effect scripts in `Scripts/cards/effects/EffectStopgap.gd`, `EffectRespite.gd`, `EffectZeroSum.gd` and wired them into `Resources/cards/card_catalog.tres`.
- Implemented zero-sum mechanics in the rules engine by adding `Rules.apply_move_with_zero_sum`, checker tagging helpers `checker_is_zero_sum` / `set_checker_zero_sum`, and a `ZeroSumResult` enum to encode outcomes (both destroyed / moving-zero hits regular / regular hits zero); updated callers to use the new API (AI adapter, several card effects, tunnel moves, and internal simulators).
- Extended `RoundController` to store and manage persistent stopgap/respite/zero-sum state with activation functions (`activate_stopgap`, `activate_respite`, `activate_zero_sum`), lifecycle checks (`_refresh_stopgap_modifiers`, `_respite_intact`, `_refresh_respite`), start-of-turn stopgap heals (`_apply_stopgap_turn_start_heals`) and respite landing heal logic (`_apply_respite_if_needed`), and integrated zero-sum HP effects via `apply_move_with_zero_sum`.
- UI and visuals: added `StopgapLayer` to `Scenes/board/BoardView.tscn`, `BoardView` support for `set_stopgap_points`, `CheckerSprite` shader support via `Shaders/zero_sum_overlay.gdshader` and a visual hook in `BoardPieces._apply_zero_sum_visual` to apply a colored overlay to zero-sum checkers.
- Updated several card effect scripts to call the new move API when relevant so zero-sum interactions are resolved consistently in both player and AI move simulations (e.g., `EffectEngulf.gd`, `EffectSuperiority.gd`, `EffectFlanked.gd`) and updated the AI adapter to use `Rules.apply_move_with_zero_sum` during simulations.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c5166080832eb0f720f19b4c48bd)