### PR TITLE
Add new defense cards (Counter Measures, Distant Threat, Accelerator) and card tooltip summaries

### DIFF
--- a/Resources/cards/card_catalog.tres
+++ b/Resources/cards/card_catalog.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="CardCatalog" load_steps=21 format=3 uid="uid://5o2fjm0okvs0"]
+[gd_resource type="Resource" script_class="CardCatalog" load_steps=25 format=3 uid="uid://5o2fjm0okvs0"]
 
 [ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="1_gfijg"]
 [ext_resource type="Script" uid="uid://cxrrf2trr2miv" path="res://CardCatalog.gd" id="2_k16gf"]
@@ -20,8 +20,11 @@
 [ext_resource type="Resource" uid="uid://d7m5c4o2b70gk" path="res://Resources/cards/defense/stopgap.tres" id="17_defense_stopgap"]
 [ext_resource type="Resource" uid="uid://b1xfrb5idbbdq" path="res://Resources/cards/defense/respite.tres" id="18_defense_respite"]
 [ext_resource type="Resource" uid="uid://dyy7rtn7v70ja" path="res://Resources/cards/defense/zero_sum.tres" id="19_defense_zero_sum"]
+[ext_resource type="Resource" uid="uid://defensecountermeasures1" path="res://Resources/cards/defense/counter_measures_defense.tres" id="20_defense_counter_measures"]
+[ext_resource type="Resource" uid="uid://distantthreatcard1" path="res://Resources/cards/defense/distant_threat.tres" id="21_defense_distant_threat"]
+[ext_resource type="Resource" uid="uid://acceleratorcard1" path="res://Resources/cards/defense/accelerator.tres" id="22_defense_accelerator"]
 
 [resource]
 script = ExtResource("2_k16gf")
-cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum")])
+cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum"), ExtResource("20_defense_counter_measures"), ExtResource("21_defense_distant_threat"), ExtResource("22_defense_accelerator")])
 metadata/_custom_type_script = "uid://cxrrf2trr2miv"

--- a/Resources/cards/combat/counter_measures.tres
+++ b/Resources/cards/combat/counter_measures.tres
@@ -31,6 +31,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_cmf3v")
 id = "counter_measures"
 title = "Counter Measures"
+tooltip_summary = "Send two enemy checkers from the matched across pair to the bar, deal 4 damage, gain +1 base attack, and add a bonus die."
 category = 1
 pip_value = -6
 pattern = Array[ExtResource("4_cmf3v")]([SubResource("Resource_pattern_counter_measures")])

--- a/Resources/cards/combat/depth_charge.tres
+++ b/Resources/cards/combat/depth_charge.tres
@@ -24,6 +24,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("3_nhu87")
 id = "depth_charge"
 title = "Depth Charge"
+tooltip_summary = "Send the top 2 checkers from each of two adjacent black stacks to the bar and deal 4 damage."
 category = 1
 pip_value = 4
 pattern = Array[ExtResource("2_dmgx5")]([SubResource("Resource_nr47k")])

--- a/Resources/cards/combat/double_down.tres
+++ b/Resources/cards/combat/double_down.tres
@@ -15,6 +15,7 @@ metadata/_custom_type_script = "uid://y2pqqaui60qh"
 script = ExtResource("3_q5fpw")
 id = "double_down"
 title = "Double Down"
+tooltip_summary = "Set your attack multiplier to x2 for this round."
 category = 1
 pip_value = -3
 effect = SubResource("Resource_nkdh8")

--- a/Resources/cards/combat/engulf.tres
+++ b/Resources/cards/combat/engulf.tres
@@ -24,6 +24,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_e1g2h")
 id = "engulf"
 title = "Engulf"
+tooltip_summary = "Collapse two white stacks into the middle, hit if possible, and deal 2 damage."
 category = 1
 pip_value = 3
 pattern = Array[ExtResource("4_e1g2h")]([SubResource("Resource_pattern_engulf")])

--- a/Resources/cards/combat/flanked.tres
+++ b/Resources/cards/combat/flanked.tres
@@ -26,6 +26,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_2f1j3")
 id = "flanked"
 title = "Flanked"
+tooltip_summary = "Hit each flanked black stack, send one to the bar, and gain +1 base attack; deal 2 damage."
 category = 1
 pip_value = -2
 pattern = Array[ExtResource("2_et3i4")]([SubResource("Resource_jrl0b")])

--- a/Resources/cards/combat/ionic_crossbow.tres
+++ b/Resources/cards/combat/ionic_crossbow.tres
@@ -27,6 +27,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("3_hfhis")
 id = "ionic_crossbow"
 title = "Ionic Crossbow"
+tooltip_summary = "Target an enemy stack anywhere; send up to 2 checkers to the bar and deal 2 damage."
 category = 1
 pip_value = 2
 pattern = Array[ExtResource("2_01ki0")]([SubResource("Resource_cnff8")])

--- a/Resources/cards/combat/mortar.tres
+++ b/Resources/cards/combat/mortar.tres
@@ -28,6 +28,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("3_nb4f5")
 id = "mortar"
 title = "Mortar"
+tooltip_summary = "Target an enemy checker in the opposite half; send it to the bar and deal 4 damage."
 category = 1
 pip_value = 5
 pattern = Array[ExtResource("2_hpnpc")]([SubResource("Resource_eon81")])

--- a/Resources/cards/combat/one_man_army.tres
+++ b/Resources/cards/combat/one_man_army.tres
@@ -33,6 +33,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("3_wj5y7")
 id = "one_man_army"
 title = "One Man Army"
+tooltip_summary = "Destroy your lone checker to send all but one from a 4+ adjacent enemy stack to the bar; deal damage equal to those sent and take 2 HP."
 pip_value = -3
 pattern = Array[ExtResource("2_eon81")]([SubResource("Resource_eon81")])
 effect = SubResource("Resource_wj5y7")

--- a/Resources/cards/combat/quick_strike.tres
+++ b/Resources/cards/combat/quick_strike.tres
@@ -16,6 +16,7 @@ metadata/_custom_type_script = "uid://rk3y1ds9w2ejc"
 script = ExtResource("5_ut8fv")
 id = "quick_strike"
 title = "Quick Strike"
+tooltip_summary = "Gain +2 base attack this round and +2 AP."
 category = 1
 pip_value = -1
 effect = SubResource("Resource_63f2b")

--- a/Resources/cards/combat/sniper.tres
+++ b/Resources/cards/combat/sniper.tres
@@ -26,6 +26,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("4_n3o0x")
 id = "sniper"
 title = "Sniper"
+tooltip_summary = "Send the opposite single enemy checker to the bar and deal 3 damage."
 category = 1
 pattern = Array[ExtResource("3_qghcl")]([SubResource("Resource_j4ddw")])
 effect = SubResource("Resource_n3o0x")

--- a/Resources/cards/combat/subterfuge.tres
+++ b/Resources/cards/combat/subterfuge.tres
@@ -25,6 +25,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("3_nsob6")
 id = "subterfuge"
 title = "Subterfuge"
+tooltip_summary = "Send the top checker from both black flanks to the bar and deal 2 damage."
 category = 1
 pip_value = -1
 pattern = Array[ExtResource("2_2j4mb")]([SubResource("Resource_2j4mb")])

--- a/Resources/cards/combat/superiority.tres
+++ b/Resources/cards/combat/superiority.tres
@@ -31,6 +31,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_hithj")
 id = "superiority"
 title = "Superiority"
+tooltip_summary = "Send two enemy checkers to the bar, move two white checkers into their point, and deal 4 damage."
 category = 1
 pip_value = -3
 pattern = Array[ExtResource("2_g1d7s")]([SubResource("Resource_62c3r")])

--- a/Resources/cards/defense/accelerator.tres
+++ b/Resources/cards/defense/accelerator.tres
@@ -1,0 +1,36 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://acceleratorcard1"]
+
+[ext_resource type="Texture2D" uid="uid://drcmdwodd1i31" path="res://Assets/textures/cards/red deck fronts/4 minus red.jpg" id="1_accelerator"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_accelerator"]
+[ext_resource type="Script" uid="uid://effectaccelerator1" path="res://Scripts/cards/effects/EffectAccelerator.gd" id="3_accelerator"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_accelerator"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_accelerator"]
+
+[sub_resource type="Resource" id="Resource_accelerator_effect"]
+script = ExtResource("3_accelerator")
+metadata/_custom_type_script = "uid://effectaccelerator1"
+
+[sub_resource type="Resource" id="Resource_accelerator_pattern"]
+script = ExtResource("4_accelerator")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 0, 0, 0)
+mix_mins = PackedInt32Array(1, 1, 1, 1)
+mix_maxs = PackedInt32Array(15, 15, 15, 15)
+mix_requires_empty = PackedInt32Array(0, 0, 0, 0)
+mix_allow_reverse = false
+mix_same_half_only = false
+mix_max_gap = 0
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_accelerator")
+id = "accelerator"
+title = "Accelerator"
+tooltip_summary = "Gain escalating HP each white turn (+1, +2, +3... up to +10), starting immediately; can overcap."
+category = 3
+pip_value = -4
+pattern = Array[ExtResource("4_accelerator")]([SubResource("Resource_accelerator_pattern")])
+effect = SubResource("Resource_accelerator_effect")
+art_texture = ExtResource("1_accelerator")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/defense/bunker.tres
+++ b/Resources/cards/defense/bunker.tres
@@ -24,6 +24,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_bunker")
 id = "bunker"
 title = "Bunker"
+tooltip_summary = "Gain +2 base defense while the pattern holds."
 category = 3
 pip_value = 6
 pattern = Array[ExtResource("4_bunker")]([SubResource("Resource_bunker_pattern")])

--- a/Resources/cards/defense/counter_measures_defense.tres
+++ b/Resources/cards/defense/counter_measures_defense.tres
@@ -1,0 +1,40 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://defensecountermeasures1"]
+
+[ext_resource type="Texture2D" uid="uid://caxape5rjy30r" path="res://Assets/textures/cards/red deck fronts/6 minus red.jpg" id="1_counter_def"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_counter_def"]
+[ext_resource type="Script" uid="uid://effectdefensecountermeasures1" path="res://Scripts/cards/effects/EffectDefenseCounterMeasures.gd" id="3_counter_def"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_counter_def"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_counter_def"]
+
+[sub_resource type="Resource" id="Resource_counter_def_effect"]
+script = ExtResource("3_counter_def")
+metadata/_custom_type_script = "uid://effectdefensecountermeasures1"
+
+[sub_resource type="Resource" id="Resource_counter_def_pattern"]
+script = ExtResource("4_counter_def")
+kind = 4
+owner_a = 0
+owner_b = 1
+min_count_a = 1
+max_count_a = 15
+min_count_b = 1
+max_count_b = 15
+adj_either_order = true
+seq_counts = null
+mix_owners = null
+mix_mins = null
+mix_maxs = null
+mix_requires_empty = null
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_counter_def")
+id = "counter_measures_defense"
+title = "Counter Measures"
+tooltip_summary = "Gain base defense equal to your formation size advantage, or heal for the enemy advantage; tie grants both +1 defense and +1 HP."
+category = 3
+pip_value = -6
+pattern = Array[ExtResource("4_counter_def")]([SubResource("Resource_counter_def_pattern")])
+effect = SubResource("Resource_counter_def_effect")
+art_texture = ExtResource("1_counter_def")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/defense/distant_threat.tres
+++ b/Resources/cards/defense/distant_threat.tres
@@ -1,0 +1,37 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://distantthreatcard1"]
+
+[ext_resource type="Texture2D" uid="uid://dcxn2rrydunyb" path="res://Assets/textures/cards/red deck fronts/5 minus red.jpg" id="1_distant_threat"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_distant_threat"]
+[ext_resource type="Script" uid="uid://effectdistantthreat1" path="res://Scripts/cards/effects/EffectDistantThreat.gd" id="3_distant_threat"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_distant_threat"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_distant_threat"]
+
+[sub_resource type="Resource" id="Resource_distant_threat_effect"]
+script = ExtResource("3_distant_threat")
+turns = 3
+metadata/_custom_type_script = "uid://effectdistantthreat1"
+
+[sub_resource type="Resource" id="Resource_distant_threat_pattern"]
+script = ExtResource("4_distant_threat")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 0, 0, 0, 1)
+mix_mins = PackedInt32Array(1, 0, 0, 0, 3)
+mix_maxs = PackedInt32Array(1, 0, 0, 0, 15)
+mix_requires_empty = PackedInt32Array(0, 1, 1, 1, 0)
+mix_allow_reverse = true
+mix_same_half_only = false
+mix_max_gap = 0
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_distant_threat")
+id = "distant_threat"
+title = "Distant Threat"
+tooltip_summary = "Make a lone white checker invulnerable for 3 turns and prevent hit damage to white checkers."
+category = 3
+pip_value = -5
+pattern = Array[ExtResource("4_distant_threat")]([SubResource("Resource_distant_threat_pattern")])
+effect = SubResource("Resource_distant_threat_effect")
+art_texture = ExtResource("1_distant_threat")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/defense/no_mans_land.tres
+++ b/Resources/cards/defense/no_mans_land.tres
@@ -26,6 +26,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_nml")
 id = "no_mans_land"
 title = "No Man's Land"
+tooltip_summary = "Create a trap gap for 5 uses: landing on it sends the checker to the bar and heals its owner 2 HP."
 category = 3
 pip_value = 4
 pattern = Array[ExtResource("4_nml")]([SubResource("Resource_nml_pattern")])

--- a/Resources/cards/defense/respite.tres
+++ b/Resources/cards/defense/respite.tres
@@ -25,6 +25,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_respite")
 id = "respite"
 title = "Respite"
+tooltip_summary = "Once per white turn, landing on a marked point heals 4 HP (overcap)."
 category = 3
 pip_value = 2
 pattern = Array[ExtResource("4_respite")]([SubResource("Resource_respite_pattern")])

--- a/Resources/cards/defense/stopgap.tres
+++ b/Resources/cards/defense/stopgap.tres
@@ -26,6 +26,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_stopgap")
 id = "stopgap"
 title = "Stopgap"
+tooltip_summary = "Mark a gap: its occupant heals 1 HP each turn and shifts base defense (+1 white / -1 black)."
 category = 3
 pip_value = 3
 pattern = Array[ExtResource("4_stopgap")]([SubResource("Resource_stopgap_pattern")])

--- a/Resources/cards/defense/tunnel.tres
+++ b/Resources/cards/defense/tunnel.tres
@@ -29,6 +29,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_tunnel")
 id = "tunnel"
 title = "Tunnel"
+tooltip_summary = "Create a tunnel between opposite points; landing on one teleports to the other and heals 1 HP."
 category = 3
 pip_value = 5
 pattern = Array[ExtResource("4_tunnel")]([SubResource("Resource_tunnel_pattern")])

--- a/Resources/cards/defense/zero_sum.tres
+++ b/Resources/cards/defense/zero_sum.tres
@@ -30,6 +30,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("5_zero_sum")
 id = "zero_sum"
 title = "Zero Sum"
+tooltip_summary = "Mark two adjacent stacks as zero-sum for special hit outcomes."
 category = 3
 pip_value = 1
 pattern = Array[ExtResource("4_zero_sum")]([SubResource("Resource_zero_sum_pattern")])

--- a/Resources/cards/economy/Vault.tres
+++ b/Resources/cards/economy/Vault.tres
@@ -12,6 +12,7 @@ metadata/_custom_type_script = "uid://ur0p531l1ca4"
 script = ExtResource("3_bi36m")
 id = "vault"
 title = "Vault"
+tooltip_summary = "No effect defined yet."
 pip_value = -3
 pattern = Array[ExtResource("2_8bv0u")]([SubResource("Resource_dt0ps")])
 metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Scripts/CardDef.gd
+++ b/Scripts/CardDef.gd
@@ -6,6 +6,7 @@ enum Category { ECONOMY, COMBAT, TEMPO, DEFENSE }
 @export var id: String = ""
 @export var title: String = ""
 @export var category: Category = Category.ECONOMY
+@export var tooltip_summary: String = ""
 
 # Card pip value (used for burn-for-pips mode).
 # Should be in [-6..-1] or [1..6]. (0 is invalid.)

--- a/Scripts/CardSlotButton.gd
+++ b/Scripts/CardSlotButton.gd
@@ -219,7 +219,11 @@ func _refresh() -> void:
 	else:
 		status = "LOCKED | " + base
 
-	tooltip_text = status
+	var summary: String = ""
+	if card.def.tooltip_summary.strip_edges() != "":
+		summary = "\nEffect: %s" % card.def.tooltip_summary.strip_edges()
+
+	tooltip_text = status + summary
 	text = "" if (card.def.art_texture != null) else status
 
 	# Targeting/primed visuals:
@@ -236,7 +240,7 @@ func _refresh() -> void:
 		if primed_by_me:
 			_set_invert(1.0) # keep inverted while primed
 			_set_primed_visual(true)
-			tooltip_text = "TARGET: click an enemy stack"
+			tooltip_text = "TARGET: click an enemy stack" + summary
 			text = "" if (card.def.art_texture != null) else "TARGET"
 			return
 		else:

--- a/Scripts/CardSlotButton2.gd
+++ b/Scripts/CardSlotButton2.gd
@@ -103,7 +103,10 @@ func _refresh() -> void:
 	if _targeting or round.targeting_active:
 		disabled = true
 		text = "TARGET"
-		tooltip_text = "TARGET: click an enemy checker"
+		var summary: String = ""
+		if card.def.tooltip_summary.strip_edges() != "":
+			summary = "\nEffect: %s" % card.def.tooltip_summary.strip_edges()
+		tooltip_text = "TARGET: click an enemy checker" + summary
 		_set_invert(0.0)
 		return
 
@@ -128,7 +131,11 @@ func _refresh() -> void:
 	else:
 		status = "LOCKED | " + base
 
-	tooltip_text = status
+	var summary: String = ""
+	if card.def.tooltip_summary.strip_edges() != "":
+		summary = "\nEffect: %s" % card.def.tooltip_summary.strip_edges()
+
+	tooltip_text = status + summary
 	# Hide big text when art exists
 	text = "" if (card.def.art_texture != null) else status
 

--- a/Scripts/cards/effects/EffectAccelerator.gd
+++ b/Scripts/cards/effects/EffectAccelerator.gd
@@ -1,0 +1,8 @@
+extends CardEffect
+class_name EffectAccelerator
+
+func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
+	if round == null or card == null:
+		return
+	if round.has_method("activate_accelerator"):
+		round.call("activate_accelerator", card)

--- a/Scripts/cards/effects/EffectAccelerator.gd.uid
+++ b/Scripts/cards/effects/EffectAccelerator.gd.uid
@@ -1,0 +1,1 @@
+uid://effectaccelerator1

--- a/Scripts/cards/effects/EffectDefenseCounterMeasures.gd
+++ b/Scripts/cards/effects/EffectDefenseCounterMeasures.gd
@@ -1,0 +1,103 @@
+extends CardEffect
+class_name EffectDefenseCounterMeasures
+
+func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> void:
+	if round == null or round.state == null or card == null or card.def == null:
+		return
+
+	var req: PatternReq = null
+	for r: PatternReq in card.def.pattern:
+		if r != null and r.kind == PatternReq.Kind.ACROSS_ADJACENT_PAIR:
+			req = r
+			break
+
+	if req == null:
+		push_warning("[EffectDefenseCounterMeasures] No ACROSS_ADJACENT_PAIR PatternReq on card.")
+		return
+
+	var match := _find_across_adjacent_pair(req, ctx)
+	if match.is_empty():
+		push_warning("[EffectDefenseCounterMeasures] Pattern ready but could not locate matched points.")
+		return
+
+	var white_points: Array = match.get("white_points", [])
+	var black_points: Array = match.get("black_points", [])
+	var white_count: int = _sum_stack_sizes(round.state, white_points)
+	var black_count: int = _sum_stack_sizes(round.state, black_points)
+
+	if round.run_state != null:
+		if white_count > black_count:
+			round.run_state.base_defense_power = maxi(0, int(round.run_state.base_defense_power) + (white_count - black_count))
+		elif white_count < black_count:
+			round.run_state.add_player_hp(black_count - white_count)
+		else:
+			round.run_state.base_defense_power = maxi(0, int(round.run_state.base_defense_power) + 1)
+			round.run_state.add_player_hp(1)
+
+	round.emit_signal("card_consumed", card.uid)
+
+func _sum_stack_sizes(state: BoardState, points: Array) -> int:
+	var total := 0
+	for pt in points:
+		var idx: int = int(pt)
+		if idx < 0 or idx > 23:
+			continue
+		total += state.points[idx].size()
+	return total
+
+func _find_across_adjacent_pair(req: PatternReq, ctx: PatternContext) -> Dictionary:
+	for a in range(0, 23):
+		var b: int = a + 1
+		var opp_a: int = 23 - a
+		var opp_b: int = 23 - b
+
+		if _pair_matches_range(ctx, a, b, req.owner_a, req.min_count_a, req.max_count_a, req.require_empty_a) \
+		and _pair_matches_range(ctx, opp_a, opp_b, req.owner_b, req.min_count_b, req.max_count_b, req.require_empty_b):
+			return _assign_white_black(req, [a, b], [opp_a, opp_b])
+
+		if req.adj_either_order:
+			if _pair_matches_range(ctx, a, b, req.owner_b, req.min_count_b, req.max_count_b, req.require_empty_b) \
+			and _pair_matches_range(ctx, opp_a, opp_b, req.owner_a, req.min_count_a, req.max_count_a, req.require_empty_a):
+				return _assign_white_black(req, [opp_a, opp_b], [a, b])
+
+	return {}
+
+func _assign_white_black(req: PatternReq, owner_a_points: Array, owner_b_points: Array) -> Dictionary:
+	if req.owner_a == BoardState.Player.WHITE:
+		return {"white_points": owner_a_points, "black_points": owner_b_points}
+	return {"white_points": owner_b_points, "black_points": owner_a_points}
+
+func _pair_matches_range(
+	ctx: PatternContext,
+	point_a: int,
+	point_b: int,
+	owner: int,
+	min_c: int,
+	max_c: int,
+	require_empty: bool
+) -> bool:
+	return _point_matches_range(ctx, point_a, owner, min_c, max_c, require_empty) \
+	and _point_matches_range(ctx, point_b, owner, min_c, max_c, require_empty)
+
+func _point_matches_range(
+	ctx: PatternContext,
+	point_i: int,
+	owner: int,
+	min_c: int,
+	max_c: int,
+	require_empty: bool
+) -> bool:
+	if point_i < 0 or point_i > 23:
+		return false
+
+	var st: PackedInt32Array = ctx.state.points[point_i]
+	var n: int = st.size()
+
+	if require_empty:
+		return n == 0
+	if n == 0:
+		return false
+	if ctx.state.owner_of(int(st[0])) != owner:
+		return false
+
+	return n >= min_c and n <= max_c

--- a/Scripts/cards/effects/EffectDefenseCounterMeasures.gd.uid
+++ b/Scripts/cards/effects/EffectDefenseCounterMeasures.gd.uid
@@ -1,0 +1,1 @@
+uid://effectdefensecountermeasures1

--- a/Scripts/cards/effects/EffectDistantThreat.gd
+++ b/Scripts/cards/effects/EffectDistantThreat.gd
@@ -1,0 +1,125 @@
+extends CardEffect
+class_name EffectDistantThreat
+
+@export var turns: int = 3
+
+func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> void:
+	if round == null or round.state == null or card == null or card.def == null:
+		return
+
+	var req: PatternReq = null
+	for r: PatternReq in card.def.pattern:
+		if r != null and r.kind == PatternReq.Kind.RUN_SEQUENCE_MIXED:
+			req = r
+			break
+
+	if req == null:
+		push_warning("[EffectDistantThreat] No RUN_SEQUENCE_MIXED PatternReq on card.")
+		return
+
+	var start_point: int = PatternMatcher.find_run_sequence_mixed_start(req, ctx)
+	if start_point == -1:
+		push_warning("[EffectDistantThreat] Pattern ready but could not locate matched start.")
+		return
+
+	var sequence := _resolve_sequence(req, ctx, start_point)
+	if sequence.is_empty():
+		push_warning("[EffectDistantThreat] Pattern ready but could not resolve match orientation.")
+		return
+
+	var owners: PackedInt32Array = sequence["owners"]
+	var mins: PackedInt32Array = sequence["mins"]
+	var maxs: PackedInt32Array = sequence["maxs"]
+	var empties: PackedInt32Array = sequence["empties"]
+
+	var white_index := -1
+	for i in range(owners.size()):
+		if int(empties[i]) != 0:
+			continue
+		if int(owners[i]) == BoardState.Player.WHITE and int(mins[i]) == 1 and int(maxs[i]) == 1:
+			white_index = i
+			break
+
+	if white_index == -1:
+		push_warning("[EffectDistantThreat] No single white checker found in matched sequence.")
+		return
+
+	var white_point: int = start_point + white_index
+	if white_point < 0 or white_point > 23:
+		return
+	var st: PackedInt32Array = round.state.points[white_point]
+	if st.size() != 1:
+		return
+
+	var checker_id: int = int(st[0])
+	if round.has_method("activate_distant_threat"):
+		round.call("activate_distant_threat", checker_id, turns, card)
+
+func _resolve_sequence(req: PatternReq, ctx: PatternContext, start_point: int) -> Dictionary:
+	var owners := req.mix_owners
+	var mins := req.mix_mins
+	var maxs := req.mix_maxs
+	var empties := req.mix_requires_empty
+	if empties.size() != owners.size():
+		empties = PackedInt32Array()
+		for _i in range(owners.size()):
+			empties.append(0)
+
+	if _sequence_matches(ctx, start_point, owners, mins, maxs, empties):
+		return {"owners": owners, "mins": mins, "maxs": maxs, "empties": empties}
+
+	if req.mix_allow_reverse:
+		var owners_rev := PackedInt32Array()
+		var mins_rev := PackedInt32Array()
+		var maxs_rev := PackedInt32Array()
+		var empties_rev := PackedInt32Array()
+		for i in range(owners.size() - 1, -1, -1):
+			owners_rev.append(int(owners[i]))
+			mins_rev.append(int(mins[i]))
+			maxs_rev.append(int(maxs[i]))
+			empties_rev.append(int(empties[i]))
+		if _sequence_matches(ctx, start_point, owners_rev, mins_rev, maxs_rev, empties_rev):
+			return {"owners": owners_rev, "mins": mins_rev, "maxs": maxs_rev, "empties": empties_rev}
+
+	return {}
+
+func _sequence_matches(
+	ctx: PatternContext,
+	start_point: int,
+	owners: PackedInt32Array,
+	mins: PackedInt32Array,
+	maxs: PackedInt32Array,
+	empties: PackedInt32Array
+) -> bool:
+	for k in range(owners.size()):
+		var p_i := start_point + k
+		if int(empties[k]) != 0:
+			if ctx.state.points[p_i].size() != 0:
+				return false
+		else:
+			if not _point_matches_range(ctx, p_i, int(owners[k]), int(mins[k]), int(maxs[k]), false):
+				return false
+	return true
+
+func _point_matches_range(
+	ctx: PatternContext,
+	point_i: int,
+	owner: int,
+	min_c: int,
+	max_c: int,
+	require_empty: bool
+) -> bool:
+	if point_i < 0 or point_i > 23:
+		return false
+
+	var st: PackedInt32Array = ctx.state.points[point_i]
+	var n: int = st.size()
+
+	if require_empty:
+		return n == 0
+	if n == 0:
+		return false
+	if ctx.state.owner_of(int(st[0])) != owner:
+		return false
+
+	return n >= min_c and n <= max_c

--- a/Scripts/cards/effects/EffectDistantThreat.gd.uid
+++ b/Scripts/cards/effects/EffectDistantThreat.gd.uid
@@ -1,0 +1,1 @@
+uid://effectdistantthreat1

--- a/Scripts/core/rules/Rules.gd
+++ b/Scripts/core/rules/Rules.gd
@@ -23,6 +23,12 @@ static func _blocked_by_opponent(state: BoardState, p: int, dst: int) -> bool:
 	if dst < 0 or dst > 23:
 		return false
 	var c: int = state.stack_count(dst)
+	if c == 1:
+		var o_single: int = state.stack_owner(dst)
+		if o_single != -1 and o_single != p:
+			var st_single: PackedInt32Array = state.points[dst]
+			if st_single.size() == 1 and checker_is_distant_threat(state, int(st_single[0])):
+				return true
 	if c < 2:
 		return false
 	var o: int = state.stack_owner(dst)
@@ -31,7 +37,15 @@ static func _blocked_by_opponent(state: BoardState, p: int, dst: int) -> bool:
 static func _is_hit(state: BoardState, p: int, dst: int) -> bool:
 	if dst < 0 or dst > 23:
 		return false
-	return state.stack_count(dst) == 1 and state.stack_owner(dst) != -1 and state.stack_owner(dst) != p
+	if state.stack_count(dst) != 1:
+		return false
+	var owner: int = state.stack_owner(dst)
+	if owner == -1 or owner == p:
+		return false
+	var st: PackedInt32Array = state.points[dst]
+	if st.size() == 1 and checker_is_distant_threat(state, int(st[0])):
+		return false
+	return true
 
 static func all_in_home(state: BoardState, p: int) -> bool:
 	var hr: Vector2i = _home_range(p)
@@ -267,6 +281,12 @@ static func checker_is_zero_sum(state: BoardState, checker_id: int) -> bool:
 		return false
 	var info: CheckerInfo = state.checkers[checker_id]
 	return bool(info.tags.get("zero_sum", false))
+
+static func checker_is_distant_threat(state: BoardState, checker_id: int) -> bool:
+	if not state.checkers.has(checker_id):
+		return false
+	var info: CheckerInfo = state.checkers[checker_id]
+	return bool(info.tags.get("distant_threat", false))
 
 static func set_checker_zero_sum(state: BoardState, checker_id: int, enabled: bool) -> void:
 	if not state.checkers.has(checker_id):

--- a/Scripts/view/board/components/BoardPieces.gd
+++ b/Scripts/view/board/components/BoardPieces.gd
@@ -131,6 +131,7 @@ func _ensure_node(state: BoardState, id: int) -> void:
 	elif piece.has_method("set_color_animation"):
 		piece.call("set_color_animation", is_white)
 	_apply_zero_sum_visual(state, id, piece)
+	_apply_distant_threat_visual(state, id, piece)
 
 func _apply_zero_sum_visual(state: BoardState, id: int, piece: Node2D) -> void:
 	if not piece.has_method("set_zero_sum_state"):
@@ -140,6 +141,14 @@ func _apply_zero_sum_visual(state: BoardState, id: int, piece: Node2D) -> void:
 	var is_white: bool = (state.owner_of(id) == BoardState.Player.WHITE)
 	var color: Color = Color(0.2, 0.6, 1.0, 0.55) if is_white else Color(1.0, 0.2, 0.2, 0.55)
 	piece.call("set_zero_sum_state", zero_sum, color)
+
+func _apply_distant_threat_visual(state: BoardState, id: int, piece: Node2D) -> void:
+	if not piece.has_method("set_distant_threat_state"):
+		return
+	var info: CheckerInfo = state.checkers.get(id, null)
+	var active: bool = info != null and bool(info.tags.get("distant_threat", false))
+	var turns_left: int = int(info.tags.get("distant_threat_turns", 0)) if info != null else 0
+	piece.call("set_distant_threat_state", active, turns_left)
 
 
 func point_stack_dir_global(i: int) -> Vector2:

--- a/Shaders/distant_threat_glow.gdshader
+++ b/Shaders/distant_threat_glow.gdshader
@@ -1,0 +1,11 @@
+shader_type canvas_item;
+
+uniform float pulse_speed = 2.6;
+uniform float glow_strength = 0.65;
+
+void fragment() {
+	vec4 tex = texture(TEXTURE, UV);
+	float pulse = (sin(TIME * pulse_speed) * 0.5 + 0.5);
+	vec3 glow = mix(tex.rgb, vec3(1.0), glow_strength * pulse);
+	COLOR = vec4(glow, tex.a);
+}

--- a/Shaders/distant_threat_glow.gdshader.uid
+++ b/Shaders/distant_threat_glow.gdshader.uid
@@ -1,0 +1,1 @@
+uid://distantthreatglow1


### PR DESCRIPTION
### Motivation
- Implement three requested defense cards (Counter Measures, Distant Threat, Accelerator) with on-board patterns and runtime behavior to expand defensive options.
- Surface a short, human-readable effect summary for cards in the UI so players can quickly understand card results without opening assets.

### Description
- Added a new exported field `tooltip_summary` to `CardDef` and updated `CardSlotButton.gd` and `CardSlotButton2.gd` to append the summary to the existing hover tooltip (and to targeting tooltips).
- Added card resource files and catalog entries for three defense cards: `counter_measures_defense.tres`, `distant_threat.tres`, and `accelerator.tres`, and added tooltip summaries to all existing card `.tres` resources.
- Implemented effect scripts: `EffectDefenseCounterMeasures.gd` (applies formation-based defense/HP scaling), `EffectDistantThreat.gd` (marks a lone checker invulnerable for N turns), and `EffectAccelerator.gd` (activates escalating per-turn healing), plus their UID files and wired them into the catalog.
- Integrated runtime support: `Rules.gd` now checks a `distant_threat` checker tag to block hits/entry where appropriate, and `RoundController.gd` now manages distant threat lifecycle, tags, board sync, and the accelerator healing ramp across white turns.
- Added board visuals and UX: `CheckerSprite.gd` and `BoardPieces.gd` now support a pulsing shader and an overlay label for distant threat checkers, and a `Shaders/distant_threat_glow.gdshader` was added.

### Testing
- No automated tests were executed for these changes (none were requested); changes were validated by code edits and project file updates and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696acab6ac10832e95799fb28435f12d)