### PR TITLE
Add Overwatch, Pacifism, and Detente defense cards and gameplay/UI support

### DIFF
--- a/Resources/cards/card_catalog.tres
+++ b/Resources/cards/card_catalog.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="CardCatalog" load_steps=24 format=3 uid="uid://5o2fjm0okvs0"]
+[gd_resource type="Resource" script_class="CardCatalog" load_steps=27 format=3 uid="uid://5o2fjm0okvs0"]
 
 [ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="1_gfijg"]
 [ext_resource type="Script" uid="uid://cxrrf2trr2miv" path="res://CardCatalog.gd" id="2_k16gf"]
@@ -23,8 +23,11 @@
 [ext_resource type="Resource" uid="uid://c0i6wt6x0cmiw" path="res://Resources/cards/defense/counter_measures_defense.tres" id="20_defense_counter_measures"]
 [ext_resource type="Resource" uid="uid://lr6dia8qtl4g" path="res://Resources/cards/defense/distant_threat.tres" id="21_defense_distant_threat"]
 [ext_resource type="Resource" uid="uid://dr3nv2hlfpmky" path="res://Resources/cards/defense/accelerator.tres" id="22_defense_accelerator"]
+[ext_resource type="Resource" uid="uid://overwatchcard1" path="res://Resources/cards/defense/overwatch.tres" id="23_defense_overwatch"]
+[ext_resource type="Resource" uid="uid://pacifismcard1" path="res://Resources/cards/defense/pacifism.tres" id="24_defense_pacifism"]
+[ext_resource type="Resource" uid="uid://detentecard1" path="res://Resources/cards/defense/detente.tres" id="25_defense_detente"]
 
 [resource]
 script = ExtResource("2_k16gf")
-cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum"), ExtResource("20_defense_counter_measures"), ExtResource("21_defense_distant_threat"), ExtResource("22_defense_accelerator")])
+cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum"), ExtResource("20_defense_counter_measures"), ExtResource("21_defense_distant_threat"), ExtResource("22_defense_accelerator"), ExtResource("23_defense_overwatch"), ExtResource("24_defense_pacifism"), ExtResource("25_defense_detente")])
 metadata/_custom_type_script = "uid://cxrrf2trr2miv"

--- a/Resources/cards/defense/detente.tres
+++ b/Resources/cards/defense/detente.tres
@@ -1,0 +1,37 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://detentecard1"]
+
+[ext_resource type="Texture2D" uid="uid://b1dcahsjb6dqn" path="res://Assets/textures/cards/blue deck fronts/1 minus blue.jpg" id="1_detente"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_detente"]
+[ext_resource type="Script" uid="uid://effectdetente1" path="res://Scripts/cards/effects/EffectDetente.gd" id="3_detente"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_detente"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_detente"]
+
+[sub_resource type="Resource" id="Resource_detente_effect"]
+script = ExtResource("3_detente")
+turns = 4
+metadata/_custom_type_script = "uid://effectdetente1"
+
+[sub_resource type="Resource" id="Resource_detente_pattern"]
+script = ExtResource("4_detente")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 1)
+mix_mins = PackedInt32Array(2, 2)
+mix_maxs = PackedInt32Array(2, 2)
+mix_requires_empty = PackedInt32Array(0, 0)
+mix_allow_reverse = true
+mix_same_half_only = false
+mix_max_gap = 0
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_detente")
+id = "detente"
+title = "Detente"
+tooltip_summary = "Declare detente: no hits are legal for the next 2 full turns."
+category = 3
+pip_value = -1
+pattern = Array[ExtResource("4_detente")]([SubResource("Resource_detente_pattern")])
+effect = SubResource("Resource_detente_effect")
+art_texture = ExtResource("1_detente")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/defense/overwatch.tres
+++ b/Resources/cards/defense/overwatch.tres
@@ -1,0 +1,36 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://overwatchcard1"]
+
+[ext_resource type="Texture2D" uid="uid://d19uw7p1fovj3" path="res://Assets/textures/cards/blue deck fronts/3 minus blue.jpg" id="1_overwatch"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_overwatch"]
+[ext_resource type="Script" uid="uid://effectoverwatch1" path="res://Scripts/cards/effects/EffectOverwatch.gd" id="3_overwatch"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_overwatch"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_overwatch"]
+
+[sub_resource type="Resource" id="Resource_overwatch_effect"]
+script = ExtResource("3_overwatch")
+metadata/_custom_type_script = "uid://effectoverwatch1"
+
+[sub_resource type="Resource" id="Resource_overwatch_pattern"]
+script = ExtResource("4_overwatch")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 0)
+mix_mins = PackedInt32Array(3, 3)
+mix_maxs = PackedInt32Array(15, 15)
+mix_requires_empty = PackedInt32Array(0, 0)
+mix_allow_reverse = false
+mix_same_half_only = true
+mix_max_gap = 0
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_overwatch")
+id = "overwatch"
+title = "Overwatch"
+tooltip_summary = "Formation: while active this round, black bear-offs deal no HP damage."
+category = 3
+pip_value = -3
+pattern = Array[ExtResource("4_overwatch")]([SubResource("Resource_overwatch_pattern")])
+effect = SubResource("Resource_overwatch_effect")
+art_texture = ExtResource("1_overwatch")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/defense/pacifism.tres
+++ b/Resources/cards/defense/pacifism.tres
@@ -1,0 +1,36 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://pacifismcard1"]
+
+[ext_resource type="Texture2D" uid="uid://bxm4d0v84n0a3" path="res://Assets/textures/cards/blue deck fronts/2 minus blue.jpg" id="1_pacifism"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_pacifism"]
+[ext_resource type="Script" uid="uid://effectpacifism1" path="res://Scripts/cards/effects/EffectPacifism.gd" id="3_pacifism"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_pacifism"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_pacifism"]
+
+[sub_resource type="Resource" id="Resource_pacifism_effect"]
+script = ExtResource("3_pacifism")
+metadata/_custom_type_script = "uid://effectpacifism1"
+
+[sub_resource type="Resource" id="Resource_pacifism_pattern"]
+script = ExtResource("4_pacifism")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 1, 0, 1)
+mix_mins = PackedInt32Array(1, 1, 1, 1)
+mix_maxs = PackedInt32Array(1, 1, 1, 1)
+mix_requires_empty = PackedInt32Array(0, 0, 0, 0)
+mix_allow_reverse = true
+mix_same_half_only = false
+mix_max_gap = 0
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_pacifism")
+id = "pacifism"
+title = "Pacifism"
+tooltip_summary = "Mark four alternating single checkers as pacifists; pacifists cannot hit, heal on friendly landings, punish hits, and grant +5 HP on bear-off."
+category = 3
+pip_value = -2
+pattern = Array[ExtResource("4_pacifism")]([SubResource("Resource_pacifism_pattern")])
+effect = SubResource("Resource_pacifism_effect")
+art_texture = ExtResource("1_pacifism")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Scenes/board/BoardView.tscn
+++ b/Scenes/board/BoardView.tscn
@@ -359,6 +359,22 @@ highlight_scale = 0.2
 
 [node name="StopgapLayer" type="Node2D" parent="."]
 
+[node name="OverwatchLabel" type="Label" parent="."]
+position = Vector2(1214, 84)
+text = "(No HP damage)"
+visible = false
+horizontal_alignment = 1
+vertical_alignment = 1
+scale = Vector2(0.7, 0.7)
+
+[node name="DetenteLabel" type="Label" parent="."]
+position = Vector2(640, 976)
+text = "Detente"
+visible = false
+horizontal_alignment = 1
+vertical_alignment = 1
+scale = Vector2(0.9, 0.9)
+
 [node name="BarClickWhite" type="Area2D" parent="."]
 position = Vector2(644.6667, 70)
 

--- a/Scripts/RunState.gd
+++ b/Scripts/RunState.gd
@@ -65,6 +65,12 @@ func add_player_hp_overcap(delta: int) -> int:
 	player_hp = maxi(0, before + int(delta))
 	return int(player_hp) - before
 
+func add_enemy_hp_overcap(delta: int) -> int:
+	# Like add_enemy_hp, but allows HP to exceed enemy_max_hp (overcap healing).
+	var before := int(enemy_hp)
+	enemy_hp = maxi(0, before + int(delta))
+	return int(enemy_hp) - before
+
 func cycle_gold_convert_mode() -> int:
 	gold_convert_mode = int(gold_convert_mode) + 1
 	if gold_convert_mode > GoldConvertMode.PIPS:

--- a/Scripts/cards/effects/EffectDetente.gd
+++ b/Scripts/cards/effects/EffectDetente.gd
@@ -1,0 +1,10 @@
+extends CardEffect
+class_name EffectDetente
+
+@export var turns: int = 4
+
+func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
+	if round == null or card == null or card.def == null:
+		return
+	if round.has_method("activate_detente"):
+		round.call("activate_detente", turns, card)

--- a/Scripts/cards/effects/EffectOverwatch.gd
+++ b/Scripts/cards/effects/EffectOverwatch.gd
@@ -1,0 +1,8 @@
+extends CardEffect
+class_name EffectOverwatch
+
+func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
+	if round == null or card == null or card.def == null:
+		return
+	if round.has_method("activate_overwatch"):
+		round.call("activate_overwatch", card)

--- a/Scripts/cards/effects/EffectPacifism.gd
+++ b/Scripts/cards/effects/EffectPacifism.gd
@@ -1,0 +1,38 @@
+extends CardEffect
+class_name EffectPacifism
+
+func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> void:
+	if round == null or round.state == null or card == null or card.def == null:
+		return
+
+	var req: PatternReq = null
+	for r: PatternReq in card.def.pattern:
+		if r != null and r.kind == PatternReq.Kind.RUN_SEQUENCE_MIXED:
+			req = r
+			break
+
+	if req == null:
+		push_warning("[EffectPacifism] No RUN_SEQUENCE_MIXED PatternReq on card.")
+		return
+
+	var start_point: int = PatternMatcher.find_run_sequence_mixed_start(req, ctx)
+	if start_point == -1:
+		push_warning("[EffectPacifism] Pattern ready but could not locate matched start.")
+		return
+
+	var checker_ids: Array[int] = []
+	for offset in range(req.mix_owners.size()):
+		var point_i := start_point + offset
+		if point_i < 0 or point_i > 23:
+			continue
+		var st: PackedInt32Array = round.state.points[point_i]
+		if st.size() != 1:
+			continue
+		checker_ids.append(int(st[0]))
+
+	if checker_ids.size() != req.mix_owners.size():
+		push_warning("[EffectPacifism] Expected %d single checkers, found %d." % [req.mix_owners.size(), checker_ids.size()])
+		return
+
+	if round.has_method("activate_pacifism"):
+		round.call("activate_pacifism", checker_ids, card)

--- a/Scripts/core/state/BoardState.gd
+++ b/Scripts/core/state/BoardState.gd
@@ -13,6 +13,7 @@ var off_white: PackedInt32Array = PackedInt32Array()
 var off_black: PackedInt32Array = PackedInt32Array()
 
 var turn: int = Player.WHITE
+var detente_turns_left: int = 0
 
 # ID registry
 var next_id: int = 1
@@ -62,6 +63,7 @@ func reset_standard() -> void:
 	checkers.clear()
 	next_id = 1
 	turn = Player.WHITE
+	detente_turns_left = 0
 
 	_spawn_stack(0, Player.WHITE, 2)
 	_spawn_stack(11, Player.WHITE, 5)

--- a/Scripts/view/board/BoardView.gd
+++ b/Scripts/view/board/BoardView.gd
@@ -16,6 +16,8 @@ signal bar_clicked(player: int)
 @onready var highlights: BoardHighlights = $HighlightsLayer
 @onready var no_mans_land_layer: Node2D = get_node_or_null("NoMansLandLayer") as Node2D
 @onready var stopgap_layer: Node2D = get_node_or_null("StopgapLayer") as Node2D
+@onready var overwatch_label: Label = get_node_or_null("OverwatchLabel") as Label
+@onready var detente_label: Label = get_node_or_null("DetenteLabel") as Label
 
 var _no_mans_land_labels: Dictionary = {}
 var _stopgap_labels: Dictionary = {}
@@ -103,6 +105,16 @@ func set_stopgap_points(points: Array) -> void:
 		label.position = pos + Vector2(-18, -22)
 		stopgap_layer.add_child(label)
 		_stopgap_labels[point] = label
+
+func set_overwatch_active(active: bool) -> void:
+	if overwatch_label == null:
+		return
+	overwatch_label.visible = active
+
+func set_detente_active(active: bool) -> void:
+	if detente_label == null:
+		return
+	detente_label.visible = active
 
 func animate_move_persistent(state: BoardState, move: Dictionary, player: int, done: Callable) -> void:
 	input.set_enabled(false)

--- a/Scripts/view/board/CheckerSprite.gd
+++ b/Scripts/view/board/CheckerSprite.gd
@@ -15,6 +15,7 @@ var checker_id: int = -1
 var _zero_sum_material: ShaderMaterial = null
 var _distant_threat_material: ShaderMaterial = null
 var _distant_threat_label: Label = null
+var _pacifism_label: Label = null
 
 const ZERO_SUM_SHADER_PATH := "res://Shaders/zero_sum_overlay.gdshader"
 const DISTANT_THREAT_SHADER_PATH := "res://Shaders/distant_threat_glow.gdshader"
@@ -82,6 +83,11 @@ func set_distant_threat_state(enabled: bool, turns_left: int) -> void:
 		_distant_threat_label.text = str(maxi(1, turns_left))
 		_distant_threat_label.visible = true
 
+func set_pacifism_state(enabled: bool) -> void:
+	_ensure_pacifism_label()
+	if _pacifism_label != null:
+		_pacifism_label.visible = enabled
+
 func _ensure_distant_threat_label() -> void:
 	if _distant_threat_label != null:
 		return
@@ -100,6 +106,25 @@ func _ensure_distant_threat_label() -> void:
 	label.visible = false
 	add_child(label)
 	_distant_threat_label = label
+
+func _ensure_pacifism_label() -> void:
+	if _pacifism_label != null:
+		return
+	var existing: Label = get_node_or_null("PacifismLabel") as Label
+	if existing != null:
+		_pacifism_label = existing
+		return
+	var label := Label.new()
+	label.name = "PacifismLabel"
+	label.text = "P"
+	label.z_index = 2001
+	label.scale = Vector2(0.75, 0.75)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	label.position = Vector2(-6, -4)
+	label.visible = false
+	add_child(label)
+	_pacifism_label = label
 
 func _on_click_area_input_event(_vp: Viewport, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:

--- a/Scripts/view/board/components/BoardPieces.gd
+++ b/Scripts/view/board/components/BoardPieces.gd
@@ -132,6 +132,7 @@ func _ensure_node(state: BoardState, id: int) -> void:
 		piece.call("set_color_animation", is_white)
 	_apply_zero_sum_visual(state, id, piece)
 	_apply_distant_threat_visual(state, id, piece)
+	_apply_pacifism_visual(state, id, piece)
 
 func _apply_zero_sum_visual(state: BoardState, id: int, piece: Node2D) -> void:
 	if not piece.has_method("set_zero_sum_state"):
@@ -149,6 +150,13 @@ func _apply_distant_threat_visual(state: BoardState, id: int, piece: Node2D) -> 
 	var active: bool = info != null and bool(info.tags.get("distant_threat", false))
 	var turns_left: int = int(info.tags.get("distant_threat_turns", 0)) if info != null else 0
 	piece.call("set_distant_threat_state", active, turns_left)
+
+func _apply_pacifism_visual(state: BoardState, id: int, piece: Node2D) -> void:
+	if not piece.has_method("set_pacifism_state"):
+		return
+	var info: CheckerInfo = state.checkers.get(id, null)
+	var active: bool = info != null and bool(info.tags.get("pacifism", false))
+	piece.call("set_pacifism_state", active)
 
 
 func point_stack_dir_global(i: int) -> Vector2:


### PR DESCRIPTION
### Motivation
- Add three new defense cards (Overwatch, Pacifism, Detente) with the intended formation patterns, tooltips, and artwork so they can appear in the card catalog and be used in runs.
- Implement the gameplay semantics for these cards: formation-based protections (Overwatch), non‑hitting pacifist checkers with landing/bear‑off heals and hit penalties, and a temporary global no‑hit Detente state.
- Surface simple UI indicators so players can see Overwatch/Detente state and Pacifism checkers on the board.

### Description
- Added card resources and registered them in the catalog: `Resources/cards/defense/overwatch.tres`, `pacifism.tres`, and `detente.tres`, each with `tooltip_summary` and art references.
- Implemented effect resources and runners: new scripts `Scripts/cards/effects/EffectOverwatch.gd`, `EffectPacifism.gd`, and `EffectDetente.gd` that call into `RoundController` activation methods.
- Game rules and state updates: added `detente_turns_left` to `BoardState`; updated `Rules` to make single-opponent hits illegal during detente and added pacifism checks that prevent pacifist checkers from hitting; implemented pacifism hit resolution (both to bar + pacifism penalty flag) in `Rules.apply_move_with_zero_sum`.
- RoundController logic: added `activate_overwatch`, `activate_detente`, and `activate_pacifism`; detente countdown tick (`_tick_detente_end_turn`); overwatch suppresses black bear‑off HP damage; pacifism landing and bear‑off healing (including overcap) and pacifism hit damage application.
- UI/visuals: added board labels (`OverwatchLabel`, `DetenteLabel`) to `Scenes/board/BoardView.tscn` and sync methods in `BoardView.gd`; added pacifism label on checkers in `CheckerSprite.gd` and wiring in `BoardPieces.gd` to apply visuals from `CheckerInfo.tags`.
- Minor supporting changes: `RunState.add_enemy_hp_overcap` added; AI/state clones copy `detente_turns_left`; helper to peek moving checker id added to properly credit pacifism/bear‑off effects.

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf518d14c832ebf906a2a64f506f9)