### PR TITLE
Accelerator persistence, white-hit damage, hand redraw (R), and skill-tree thresholds

### DIFF
--- a/SkillTreeManager.gd
+++ b/SkillTreeManager.gd
@@ -4,7 +4,7 @@ class_name SkillTreeManager
 signal request_open(options: Array, picks_allowed: int)
 signal selection_confirmed(chosen_ids: Array, gold_spent: int)
 
-@export var thresholds: PackedFloat32Array = PackedFloat32Array([0.75, 0.50]) # remaining ratio triggers
+@export var thresholds: PackedFloat32Array = PackedFloat32Array([0.90, 0.75, 0.50]) # remaining ratio triggers
 @export var options_shown: int = 5
 
 @export var picks_base: int = 1


### PR DESCRIPTION
### Motivation
- Ensure the Accelerator card's HP-granting effect is revoked when the required 4-point white formation is broken.  
- Make WHITE hits deal 1 HP (scaled by base attack and player attack multiplier) to BLACK when a hit occurs.  
- Add a player-facing card redraw feature (cost 1 AP) to quickly replace the current hand, accessible via the `R` key for now.  
- Trigger skill-tree (aux) selection earlier by changing pip remaining thresholds to 90%, 75%, and 50%.

### Description
- Added call to `_apply_white_hit_damage(move, result, player)` from `apply_move_with_zero_sum` in `Scripts/game/RoundController.gd` and implemented `_apply_white_hit_damage` to call `deal_enemy_damage(1, true)` so the 1 HP hit is scaled by `run_state.base_attack_power` and `run_state.player_attack_mult`.  
- Implemented accelerator persistence checks with `_accelerator_intact()` (scans for any run of 4 consecutive white-owned non-empty points) and auto-deactivation via `_deactivate_accelerator()` when the pattern breaks, and wired this into `_refresh_persistent_effects()` in `Scripts/game/RoundController.gd`.  
- Added hand-redraw flow: `request_redraw_hand()` (consumes 1 AP, moves current hand cards to `discard_pile`, fills hand from `draw_pile`, and emits `hand_changed`) plus `_unhandled_input` handling to catch `KEY_R` and call the redraw, and enabled unhandled input processing with `set_process_unhandled_input(true)` in `RoundController`.  
- Updated skill tree trigger thresholds in `SkillTreeManager.gd` by changing the exported `thresholds` array to `PackedFloat32Array([0.90, 0.75, 0.50])` so selection opens at 90%, 75%, and 50% pips remaining.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db58d22f4832eb6115150a2d56e3d)