### PR TITLE
Add sepia pulse to card invert/glow shader

### DIFF
--- a/Shaders/card_invert_glow.gdshader
+++ b/Shaders/card_invert_glow.gdshader
@@ -6,12 +6,24 @@ uniform float glow_strength : hint_range(0.0, 3.0) = 0.0;
 uniform float pulse_speed : hint_range(0.0, 10.0) = 3.0;
 uniform vec4 glow_color : source_color = vec4(0.70, 0.20, 1.00, 1.0); // brighter purple
 
+uniform float sepia_speed : hint_range(0.0, 10.0) = 1.5;
+uniform float sepia_max : hint_range(0.0, 1.0) = 0.0;
+
 uniform float edge_width : hint_range(0.0, 0.25) = 0.12;   // thicker edge band
 uniform float aura_strength : hint_range(0.0, 3.0) = 0.9;  // center aura
 
 void fragment() {
 	vec4 tex = texture(TEXTURE, UV);
 	vec4 base = tex * COLOR;
+
+	float sepia_amount = (sin(TIME * sepia_speed) * 0.5 + 0.5) * sepia_max;
+	mat3 sepia_matrix = mat3(
+		vec3(0.393, 0.769, 0.189),
+		vec3(0.349, 0.686, 0.168),
+		vec3(0.272, 0.534, 0.131)
+	);
+	vec3 sepia_color = sepia_matrix * base.rgb;
+	base.rgb = mix(base.rgb, sepia_color, sepia_amount);
 
 	// Invert
 	vec3 inv = vec3(1.0) - base.rgb;


### PR DESCRIPTION
### Motivation
- Add a time-varying sepia tint to card visuals so cards can pulse between original and sepia tones.
- Keep the existing invert and glow behavior intact so other visual states are unchanged.

### Description
- Added uniforms `sepia_speed` and `sepia_max` to `Shaders/card_invert_glow.gdshader` for controlling oscillation speed and maximum sepia amount.
- Compute `sepia_amount` with `(sin(TIME * sepia_speed) * 0.5 + 0.5) * sepia_max` and construct a standard sepia `mat3` to produce `sepia_color`.
- Blend the sepia result into the base color with `base.rgb = mix(base.rgb, sepia_color, sepia_amount)` before applying the existing invert and glow logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f7085acc832e93527012934417e7)