### PR TITLE
Apply sepia-oscillation shader to CardSlotButton art

### DIFF
--- a/Scenes/CardSlotButton.tscn
+++ b/Scenes/CardSlotButton.tscn
@@ -12,6 +12,8 @@ shader_parameter/pulse_speed = 3.70000017575
 shader_parameter/glow_color = Color(0.68502325, 0.24280238, 0.21141896, 1)
 shader_parameter/edge_width = 0.12
 shader_parameter/aura_strength = 1.02000004845
+shader_parameter/sepia_speed = 1.0
+shader_parameter/sepia_max = 1.0
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_d81wn"]
 blend_mode = 1

--- a/Scripts/CardSlotButton.gd
+++ b/Scripts/CardSlotButton.gd
@@ -114,23 +114,23 @@ func _ensure_invert_material() -> void:
 	if art == null:
 		return
 
-	# Prefer the simpler invert shader if you have it; fall back to the glow shader if not.
-	var shader: Shader = load("res://Shaders/invert_card.gdshader") as Shader
-	if shader == null:
-		shader = load("res://Shaders/card_invert_glow.gdshader") as Shader
-
+	# Prefer the sepia-capable glow shader so we can oscillate the card art.
+	var shader: Shader = load("res://Shaders/card_invert_glow.gdshader") as Shader
 	if shader == null:
 		# If no shader exists, we can still function; invert just won't happen
-		push_warning("[CardSlotButton] No invert shader found (invert_card.gdshader or card_invert_glow.gdshader).")
+		push_warning("[CardSlotButton] No invert shader found (card_invert_glow.gdshader).")
 		return
 
 	var sm := art.material as ShaderMaterial
-	if sm != null and sm.shader == shader:
-		return
+	if sm == null or sm.shader != shader:
+		sm = ShaderMaterial.new()
+		sm.shader = shader
+		art.material = sm
 
-	var mat := ShaderMaterial.new()
-	mat.shader = shader
-	art.material = mat
+	if sm.has_shader_parameter("sepia_speed"):
+		sm.set_shader_parameter("sepia_speed", 1.0)
+	if sm.has_shader_parameter("sepia_max"):
+		sm.set_shader_parameter("sepia_max", 1.0)
 
 func _set_invert(amount: float) -> void:
 	if art == null:

--- a/Shaders/card_invert_glow.gdshader
+++ b/Shaders/card_invert_glow.gdshader
@@ -9,6 +9,9 @@ uniform vec4 glow_color : source_color = vec4(0.70, 0.20, 1.00, 1.0); // brighte
 uniform float edge_width : hint_range(0.0, 0.25) = 0.12;   // thicker edge band
 uniform float aura_strength : hint_range(0.0, 3.0) = 0.9;  // center aura
 
+uniform float sepia_speed : hint_range(0.0, 10.0) = 1.0;
+uniform float sepia_max : hint_range(0.0, 1.0) = 0.0;
+
 void fragment() {
 	vec4 tex = texture(TEXTURE, UV);
 	vec4 base = tex * COLOR;
@@ -32,6 +35,14 @@ void fragment() {
 
 	float mask = max(edge, aura * aura_strength);
 	col += glow_color.rgb * (glow_strength * mask * pulse);
+
+	float sepia_amount = sepia_max * (0.5 + 0.5 * sin(TIME * sepia_speed));
+	vec3 sepia = vec3(
+		dot(col, vec3(0.393, 0.769, 0.189)),
+		dot(col, vec3(0.349, 0.686, 0.168)),
+		dot(col, vec3(0.272, 0.534, 0.131))
+	);
+	col = mix(col, sepia, clamp(sepia_amount, 0.0, sepia_max));
 
 	COLOR = vec4(col, base.a);
 }


### PR DESCRIPTION
### Motivation
- Enable a sepia oscillation effect on the card art TextureRect so the art can smoothly oscillate between normal and sepia tones on the board.
- Ensure the `Art` TextureRect uses the sepia-capable shader and that the initial oscillation parameters produce a 0.0→1.0 cycle as requested.

### Description
- Add `sepia_speed` and `sepia_max` uniforms to `Shaders/card_invert_glow.gdshader` and blend a computed sepia color into the final color using a `sin(TIME * sepia_speed)` oscillation scaled by `sepia_max`.
- Update `Scripts/CardSlotButton.gd` in `_ensure_invert_material()` to prefer the sepia-capable `res://Shaders/card_invert_glow.gdshader`, attach/replace the `ShaderMaterial` for the `Art` TextureRect, and set `sepia_speed` and `sepia_max` shader parameters when available.
- Seed the scene material in `Scenes/CardSlotButton.tscn` with `shader_parameter/sepia_speed = 1.0` and `shader_parameter/sepia_max = 1.0` so the effect is enabled by default.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f709c480832ebe40c32ab0a52ce7)