### PR TITLE
Add End Turn HUD button and Debug AI toggle

### DIFF
--- a/Scenes/debug_menu.tscn
+++ b/Scenes/debug_menu.tscn
@@ -88,6 +88,12 @@ layout_mode = 2
 layout_mode = 2
 text = "Roll Random"
 
+[node name="AIToggleBtn" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+layout_mode = 2
+toggle_mode = true
+button_pressed = true
+text = "AI: On"
+
 [node name="HBoxContainer6" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 

--- a/Scenes/main/RoundScene.tscn
+++ b/Scenes/main/RoundScene.tscn
@@ -1172,6 +1172,18 @@ offset_bottom = 374.0
 grow_horizontal = 2
 script = ExtResource("6_k0kue")
 
+[node name="EndTurnButton" type="Button" parent="HUD"]
+layout_mode = 1
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -220.0
+offset_top = -120.0
+offset_right = -20.0
+offset_bottom = -60.0
+text = "End Turn"
+
 [node name="RolledLabel" type="Label" parent="HUD/DiceUI"]
 layout_mode = 1
 anchors_preset = -1


### PR DESCRIPTION
### Motivation
- Provide a manual confirmation for ending the player's turn so the AI does not start until the player explicitly confirms when all rolled dice are consumed or legally unusable. 
- Expose a debug toggle to enable/disable the AI so testers can play control of Black during debugging and playtesting. 

### Description
- Added an `EndTurnButton` node to the main `RoundScene.tscn` HUD and wired it via `end_turn_button` in `RoundController.gd`, including visibility and enabled-state logic anchored to whether the turn is manual and dice/legal-move availability. 
- Implemented helper functions in `RoundController.gd`: `_is_manual_turn`, `_count_dice_only_legal_moves`, `_can_end_turn_now`, `_update_end_turn_button`, and `_on_end_turn_pressed`, and updated turn-progression hooks to defer automatic end-turn when manual flow is active. 
- Added a debug UI toggle button (`AIToggleBtn`) in `Scenes/debug_menu.tscn` and `Scenes/DebugMenu.gd` with a `request_ai_enabled` signal and `set_ai_enabled` helper, and hooked the debug toggle into `RoundController.gd` to start/stop AI and enable manual Black input. 

### Testing
- No automated tests were run as part of this change. 
- Basic sanity checks performed by wiring signals and calling `git commit` (no runtime test harness execution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69719e0d1674832ea304ff4cf5cef00a)