### PR TITLE
Add tempo card entries: Accelerator, Quanta, Entanglement

### DIFF
--- a/Resources/cards/card_catalog.tres
+++ b/Resources/cards/card_catalog.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="CardCatalog" load_steps=35 format=3 uid="uid://5o2fjm0okvs0"]
+[gd_resource type="Resource" script_class="CardCatalog" load_steps=38 format=3 uid="uid://5o2fjm0okvs0"]
 
 [ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="1_gfijg"]
 [ext_resource type="Script" uid="uid://cxrrf2trr2miv" path="res://CardCatalog.gd" id="2_k16gf"]
@@ -22,6 +22,9 @@
 [ext_resource type="Resource" uid="uid://countermeasurestempocard1" path="res://Resources/cards/tempo/counter_measures_tempo.tres" id="19_tempo_counter_measures"]
 [ext_resource type="Resource" uid="uid://rapidretreatcard1" path="res://Resources/cards/tempo/rapid_retreat.tres" id="20_tempo_rapid_retreat"]
 [ext_resource type="Resource" uid="uid://momentumcard1" path="res://Resources/cards/tempo/momentum.tres" id="21_tempo_momentum"]
+[ext_resource type="Resource" uid="uid://tempoacceleratorcard1" path="res://Resources/cards/tempo/accelerator.tres" id="22_tempo_accelerator"]
+[ext_resource type="Resource" uid="uid://quantacard1" path="res://Resources/cards/tempo/quanta.tres" id="23_tempo_quanta"]
+[ext_resource type="Resource" uid="uid://entanglementcard1" path="res://Resources/cards/tempo/entanglement.tres" id="24_tempo_entanglement"]
 [ext_resource type="Resource" uid="uid://c0v7tqa1w4anp" path="res://Resources/cards/defense/bunker.tres" id="14_defense_bunker"]
 [ext_resource type="Resource" uid="uid://dg0a3c2ewq2u8" path="res://Resources/cards/defense/tunnel.tres" id="15_defense_tunnel"]
 [ext_resource type="Resource" uid="uid://br4p7s7pect32" path="res://Resources/cards/defense/no_mans_land.tres" id="16_defense_no_mans_land"]
@@ -37,5 +40,5 @@
 
 [resource]
 script = ExtResource("2_k16gf")
-cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_tempo_wormhole"), ExtResource("15_tempo_chain_reaction"), ExtResource("16_tempo_friction"), ExtResource("17_tempo_stealth"), ExtResource("18_tempo_recon"), ExtResource("19_tempo_counter_measures"), ExtResource("20_tempo_rapid_retreat"), ExtResource("21_tempo_momentum"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum"), ExtResource("20_defense_counter_measures"), ExtResource("21_defense_distant_threat"), ExtResource("22_defense_accelerator"), ExtResource("23_defense_overwatch"), ExtResource("24_defense_pacifism"), ExtResource("25_defense_detente")])
+cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_tempo_wormhole"), ExtResource("15_tempo_chain_reaction"), ExtResource("16_tempo_friction"), ExtResource("17_tempo_stealth"), ExtResource("18_tempo_recon"), ExtResource("19_tempo_counter_measures"), ExtResource("20_tempo_rapid_retreat"), ExtResource("21_tempo_momentum"), ExtResource("22_tempo_accelerator"), ExtResource("23_tempo_quanta"), ExtResource("24_tempo_entanglement"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum"), ExtResource("20_defense_counter_measures"), ExtResource("21_defense_distant_threat"), ExtResource("22_defense_accelerator"), ExtResource("23_defense_overwatch"), ExtResource("24_defense_pacifism"), ExtResource("25_defense_detente")])
 metadata/_custom_type_script = "uid://cxrrf2trr2miv"

--- a/Resources/cards/tempo/accelerator.tres
+++ b/Resources/cards/tempo/accelerator.tres
@@ -1,0 +1,34 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://tempoacceleratorcard1"]
+
+[ext_resource type="Texture2D" uid="uid://cywumhmimvn0" path="res://Assets/textures/cards/green deck fronts/3 minus green.jpg" id="1_tempo_accelerator"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_tempo_accelerator"]
+[ext_resource type="Script" uid="uid://tempoacceleratoreffectscript1" path="res://Scripts/cards/effects/EffectTempoAccelerator.gd" id="3_tempo_accelerator"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_tempo_accelerator"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_tempo_accelerator"]
+
+[sub_resource type="Resource" id="Resource_tempo_accelerator_effect"]
+script = ExtResource("3_tempo_accelerator")
+metadata/_custom_type_script = "uid://effecttempoaccelerator1"
+
+[sub_resource type="Resource" id="Resource_tempo_accelerator_pattern"]
+script = ExtResource("4_tempo_accelerator")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 0, 0, 0)
+mix_mins = PackedInt32Array(1, 1, 1, 1)
+mix_maxs = PackedInt32Array(15, 15, 15, 15)
+mix_requires_empty = PackedInt32Array(0, 0, 0, 0)
+mix_same_half_only = false
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_tempo_accelerator")
+id = "tempo_accelerator"
+title = "Accelerator"
+category = 2
+tooltip_summary = "Once activated, white can toggle accelerated bear-off after all checkers are home: selecting a homeboard stack bears it off for 2 AP without dice, otherwise dice are used."
+pip_value = -3
+pattern = Array[ExtResource("4_tempo_accelerator")]([SubResource("Resource_tempo_accelerator_pattern")])
+effect = SubResource("Resource_tempo_accelerator_effect")
+art_texture = ExtResource("1_tempo_accelerator")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/tempo/entanglement.tres
+++ b/Resources/cards/tempo/entanglement.tres
@@ -1,0 +1,35 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://entanglementcard1"]
+
+[ext_resource type="Texture2D" uid="uid://dtftircwy1g6n" path="res://Assets/textures/cards/green deck fronts/5 minus green.jpg" id="1_entanglement"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_entanglement"]
+[ext_resource type="Script" uid="uid://entanglementeffectscript1" path="res://Scripts/cards/effects/EffectEntanglement.gd" id="3_entanglement"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_entanglement"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_entanglement"]
+
+[sub_resource type="Resource" id="Resource_entanglement_effect"]
+script = ExtResource("3_entanglement")
+metadata/_custom_type_script = "uid://effectentanglement1"
+
+[sub_resource type="Resource" id="Resource_entanglement_pattern"]
+script = ExtResource("4_entanglement")
+kind = 2
+seq_counts = null
+mix_owners = PackedInt32Array(0, 1, 0, 1)
+mix_mins = PackedInt32Array(1, 1, 1, 1)
+mix_maxs = PackedInt32Array(1, 1, 1, 1)
+mix_requires_empty = PackedInt32Array(0, 0, 0, 0)
+mix_allow_reverse = true
+mix_same_half_only = false
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_entanglement")
+id = "entanglement"
+title = "Entanglement"
+category = 2
+tooltip_summary = "For the next 3 white turns (starting immediately), add copies of black's previous roll to white's available dice."
+pip_value = -5
+pattern = Array[ExtResource("4_entanglement")]([SubResource("Resource_entanglement_pattern")])
+effect = SubResource("Resource_entanglement_effect")
+art_texture = ExtResource("1_entanglement")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/cards/tempo/quanta.tres
+++ b/Resources/cards/tempo/quanta.tres
@@ -1,0 +1,38 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=8 format=3 uid="uid://quantacard1"]
+
+[ext_resource type="Texture2D" uid="uid://dsdhcb02ogsw7" path="res://Assets/textures/cards/green deck fronts/4 minus green.jpg" id="1_quanta"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_quanta"]
+[ext_resource type="Script" uid="uid://quantaeffectscript1" path="res://Scripts/cards/effects/EffectQuanta.gd" id="3_quanta"]
+[ext_resource type="Script" uid="uid://ur0p531l1ca4" path="res://Scripts/PatternReq.gd" id="4_quanta"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_quanta"]
+
+[sub_resource type="Resource" id="Resource_quanta_effect"]
+script = ExtResource("3_quanta")
+metadata/_custom_type_script = "uid://effectquanta1"
+
+[sub_resource type="Resource" id="Resource_quanta_pattern"]
+script = ExtResource("4_quanta")
+kind = 3
+owner_b = 0
+min_count_a = 2
+max_count_a = 2
+min_count_b = 2
+max_count_b = 2
+seq_counts = null
+mix_owners = null
+mix_mins = null
+mix_maxs = null
+mix_requires_empty = null
+metadata/_custom_type_script = "uid://ur0p531l1ca4"
+
+[resource]
+script = ExtResource("5_quanta")
+id = "quanta"
+title = "Quanta"
+category = 2
+tooltip_summary = "Maintain opposing 2x2 stacks to gain escalating +1 AP each white turn (up to +5), ending when the formation breaks."
+pip_value = -4
+pattern = Array[ExtResource("4_quanta")]([SubResource("Resource_quanta_pattern")])
+effect = SubResource("Resource_quanta_effect")
+art_texture = ExtResource("1_quanta")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Scenes/main/RoundScene.tscn
+++ b/Scenes/main/RoundScene.tscn
@@ -1184,6 +1184,20 @@ offset_right = -20.0
 offset_bottom = -60.0
 text = "End Turn"
 
+[node name="AcceleratorToggle" type="Button" parent="HUD"]
+layout_mode = 1
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -220.0
+offset_top = -175.0
+offset_right = -20.0
+offset_bottom = -135.0
+text = "Accelerator: Off"
+toggle_mode = true
+visible = false
+
 [node name="RolledLabel" type="Label" parent="HUD/DiceUI"]
 layout_mode = 1
 anchors_preset = -1

--- a/Scripts/cards/effects/EffectEntanglement.gd
+++ b/Scripts/cards/effects/EffectEntanglement.gd
@@ -1,0 +1,11 @@
+extends CardEffect
+class_name EffectEntanglement
+
+func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
+	if round == null:
+		return
+	if round.has_method("activate_entanglement"):
+		round.call("activate_entanglement", card)
+	else:
+		if card != null:
+			round.emit_signal("card_consumed", card.uid)

--- a/Scripts/cards/effects/EffectEntanglement.gd.uid
+++ b/Scripts/cards/effects/EffectEntanglement.gd.uid
@@ -1,0 +1,1 @@
+uid://effectentanglement1

--- a/Scripts/cards/effects/EffectQuanta.gd
+++ b/Scripts/cards/effects/EffectQuanta.gd
@@ -1,0 +1,11 @@
+extends CardEffect
+class_name EffectQuanta
+
+func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
+	if round == null:
+		return
+	if round.has_method("activate_quanta"):
+		round.call("activate_quanta", card)
+	else:
+		if card != null:
+			round.emit_signal("card_consumed", card.uid)

--- a/Scripts/cards/effects/EffectQuanta.gd
+++ b/Scripts/cards/effects/EffectQuanta.gd
@@ -1,11 +1,64 @@
 extends CardEffect
 class_name EffectQuanta
 
-func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
-	if round == null:
+func apply(round: RoundController, card: CardInstance, ctx: PatternContext) -> void:
+	if round == null or card == null or card.def == null:
 		return
+
+	var req: PatternReq = null
+	for r: PatternReq in card.def.pattern:
+		if r != null and r.kind == PatternReq.Kind.ACROSS_PAIR:
+			req = r
+			break
+
+	if req == null:
+		push_warning("[EffectQuanta] No ACROSS_PAIR PatternReq on card.")
+		return
+
+	var points := _find_across_pair_points(req, ctx)
+	if points.size() != 2:
+		push_warning("[EffectQuanta] Pattern ready but could not locate matched points.")
+		return
+
 	if round.has_method("activate_quanta"):
-		round.call("activate_quanta", card)
+		round.call("activate_quanta", points, card)
 	else:
-		if card != null:
-			round.emit_signal("card_consumed", card.uid)
+		round.emit_signal("card_consumed", card.uid)
+
+func _find_across_pair_points(req: PatternReq, ctx: PatternContext) -> PackedInt32Array:
+	for a in range(24):
+		var b: int = 23 - a
+		if _point_matches_range(ctx, a, req.owner_a, req.min_count_a, req.max_count_a, req.require_empty_a) \
+		and _point_matches_range(ctx, b, req.owner_b, req.min_count_b, req.max_count_b, req.require_empty_b):
+			return PackedInt32Array([a, b])
+
+		if req.adj_either_order:
+			if _point_matches_range(ctx, a, req.owner_b, req.min_count_b, req.max_count_b, req.require_empty_b) \
+			and _point_matches_range(ctx, b, req.owner_a, req.min_count_a, req.max_count_a, req.require_empty_a):
+				return PackedInt32Array([a, b])
+
+	return PackedInt32Array()
+
+func _point_matches_range(
+	ctx: PatternContext,
+	point_i: int,
+	owner: int,
+	min_c: int,
+	max_c: int,
+	require_empty: bool
+) -> bool:
+	if point_i < 0 or point_i > 23:
+		return false
+
+	var st: PackedInt32Array = ctx.state.points[point_i]
+	var n: int = st.size()
+
+	if require_empty:
+		return n == 0
+	if n == 0:
+		return false
+
+	if ctx.state.owner_of(int(st[0])) != owner:
+		return false
+
+	return n >= min_c and n <= max_c

--- a/Scripts/cards/effects/EffectQuanta.gd.uid
+++ b/Scripts/cards/effects/EffectQuanta.gd.uid
@@ -1,0 +1,1 @@
+uid://effectquanta1

--- a/Scripts/cards/effects/EffectTempoAccelerator.gd
+++ b/Scripts/cards/effects/EffectTempoAccelerator.gd
@@ -1,0 +1,11 @@
+extends CardEffect
+class_name EffectTempoAccelerator
+
+func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
+	if round == null:
+		return
+	if round.has_method("activate_tempo_accelerator"):
+		round.call("activate_tempo_accelerator", card)
+	else:
+		if card != null:
+			round.emit_signal("card_consumed", card.uid)

--- a/Scripts/cards/effects/EffectTempoAccelerator.gd.uid
+++ b/Scripts/cards/effects/EffectTempoAccelerator.gd.uid
@@ -1,0 +1,1 @@
+uid://effecttempoaccelerator1


### PR DESCRIPTION
### Motivation
- Add three new tempo cards to the game catalog (Accelerator, Quanta, Entanglement) with their activation patterns, pip costs, art, and hover tooltips so they can be used by gameplay logic.

### Description
- Added card resources at `Resources/cards/tempo/accelerator.tres`, `Resources/cards/tempo/quanta.tres`, and `Resources/cards/tempo/entanglement.tres` with `category = 2`, appropriate `pip_value` (-3, -4, -5), `pattern`, `art_texture`, and `tooltip_summary` entries.
- Registered the new cards in `Resources/cards/card_catalog.tres` so they are discovered by the `CardDB`/catalog loader.
- Added effect script stubs `Scripts/cards/effects/EffectTempoAccelerator.gd`, `Scripts/cards/effects/EffectQuanta.gd`, and `Scripts/cards/effects/EffectEntanglement.gd` (and corresponding `.uid` files) that extend `CardEffect` and invoke the round hooks `activate_tempo_accelerator`, `activate_quanta`, and `activate_entanglement` respectively when present, otherwise they emit the `card_consumed` signal.
- Patterns reuse existing `PatternReq` configurations (accelerator mirrors the defense `Accelerator` pattern kind, `Quanta` mirrors `Tunnel` 2x2 opposite pattern, and `Entanglement` mirrors the `Pacifism` alternating single-checker pattern).

### Testing
- No automated tests were run for this change (`no test suite executed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765a8a49b8832eba02d3e47df64fb2)