### PR TITLE
Add Jailbreak tempo card (allows alternate white bar entry)

### DIFF
--- a/Resources/cards/card_catalog.tres
+++ b/Resources/cards/card_catalog.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="CardCatalog" load_steps=38 format=3 uid="uid://5o2fjm0okvs0"]
+[gd_resource type="Resource" script_class="CardCatalog" load_steps=39 format=3 uid="uid://5o2fjm0okvs0"]
 
 [ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="1_gfijg"]
 [ext_resource type="Script" uid="uid://cxrrf2trr2miv" path="res://CardCatalog.gd" id="2_k16gf"]
@@ -25,6 +25,7 @@
 [ext_resource type="Resource" uid="uid://tempoacceleratorcard1" path="res://Resources/cards/tempo/accelerator.tres" id="22_tempo_accelerator"]
 [ext_resource type="Resource" uid="uid://quantacard1" path="res://Resources/cards/tempo/quanta.tres" id="23_tempo_quanta"]
 [ext_resource type="Resource" uid="uid://entanglementcard1" path="res://Resources/cards/tempo/entanglement.tres" id="24_tempo_entanglement"]
+[ext_resource type="Resource" uid="uid://jailbreakcard1" path="res://Resources/cards/tempo/jailbreak.tres" id="25_tempo_jailbreak"]
 [ext_resource type="Resource" uid="uid://c0v7tqa1w4anp" path="res://Resources/cards/defense/bunker.tres" id="14_defense_bunker"]
 [ext_resource type="Resource" uid="uid://dg0a3c2ewq2u8" path="res://Resources/cards/defense/tunnel.tres" id="15_defense_tunnel"]
 [ext_resource type="Resource" uid="uid://br4p7s7pect32" path="res://Resources/cards/defense/no_mans_land.tres" id="16_defense_no_mans_land"]
@@ -40,5 +41,5 @@
 
 [resource]
 script = ExtResource("2_k16gf")
-cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_tempo_wormhole"), ExtResource("15_tempo_chain_reaction"), ExtResource("16_tempo_friction"), ExtResource("17_tempo_stealth"), ExtResource("18_tempo_recon"), ExtResource("19_tempo_counter_measures"), ExtResource("20_tempo_rapid_retreat"), ExtResource("21_tempo_momentum"), ExtResource("22_tempo_accelerator"), ExtResource("23_tempo_quanta"), ExtResource("24_tempo_entanglement"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum"), ExtResource("20_defense_counter_measures"), ExtResource("21_defense_distant_threat"), ExtResource("22_defense_accelerator"), ExtResource("23_defense_overwatch"), ExtResource("24_defense_pacifism"), ExtResource("25_defense_detente")])
+cards = Array[ExtResource("1_gfijg")]([ExtResource("2_thl06"), ExtResource("3_ndmhq"), ExtResource("4_uwhgp"), ExtResource("5_7tsok"), ExtResource("6_ndmhq"), ExtResource("7_uwhgp"), ExtResource("8_7tsok"), ExtResource("9_8k6m4"), ExtResource("10_8k6m4"), ExtResource("11_7k4ve"), ExtResource("12_1nxdh"), ExtResource("13_jud1b"), ExtResource("14_tempo_wormhole"), ExtResource("15_tempo_chain_reaction"), ExtResource("16_tempo_friction"), ExtResource("17_tempo_stealth"), ExtResource("18_tempo_recon"), ExtResource("19_tempo_counter_measures"), ExtResource("20_tempo_rapid_retreat"), ExtResource("21_tempo_momentum"), ExtResource("22_tempo_accelerator"), ExtResource("23_tempo_quanta"), ExtResource("24_tempo_entanglement"), ExtResource("25_tempo_jailbreak"), ExtResource("14_defense_bunker"), ExtResource("15_defense_tunnel"), ExtResource("16_defense_no_mans_land"), ExtResource("17_defense_stopgap"), ExtResource("18_defense_respite"), ExtResource("19_defense_zero_sum"), ExtResource("20_defense_counter_measures"), ExtResource("21_defense_distant_threat"), ExtResource("22_defense_accelerator"), ExtResource("23_defense_overwatch"), ExtResource("24_defense_pacifism"), ExtResource("25_defense_detente")])
 metadata/_custom_type_script = "uid://cxrrf2trr2miv"

--- a/Resources/cards/tempo/jailbreak.tres
+++ b/Resources/cards/tempo/jailbreak.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" script_class="CardDef" load_steps=7 format=3 uid="uid://jailbreakcard1"]
+
+[ext_resource type="Texture2D" uid="uid://c8ylwqtmjae8n" path="res://Assets/textures/cards/green deck fronts/6 minus green.jpg" id="1_jailbreak"]
+[ext_resource type="Script" uid="uid://dxnljvcddxql4" path="res://Scripts/CardEffect.gd" id="2_jailbreak"]
+[ext_resource type="Script" uid="uid://jailbreakeffect1" path="res://Scripts/cards/effects/EffectJailbreak.gd" id="3_jailbreak"]
+[ext_resource type="Resource" uid="uid://reqwhitebar3card1" path="res://Resources/reqs/req_white_bar_3.tres" id="4_jailbreak"]
+[ext_resource type="Script" uid="uid://b1ylg81nigak7" path="res://Scripts/CardDef.gd" id="5_jailbreak"]
+
+[sub_resource type="Resource" id="Resource_jailbreak_effect"]
+script = ExtResource("3_jailbreak")
+metadata/_custom_type_script = "uid://jailbreakeffect1"
+
+[resource]
+script = ExtResource("5_jailbreak")
+id = "jailbreak"
+title = "Jailbreak"
+category = 2
+tooltip_summary = "Pattern: 3+ white checkers on the bar. For the rest of the round, white may re-enter from the bar into points 18-23 (1=23, 2=22, etc.) as well as points 0-5."
+pip_value = -6
+effect = SubResource("Resource_jailbreak_effect")
+art_texture = ExtResource("1_jailbreak")
+activation_req = ExtResource("4_jailbreak")
+metadata/_custom_type_script = "uid://b1ylg81nigak7"

--- a/Resources/reqs/req_white_bar_3.tres
+++ b/Resources/reqs/req_white_bar_3.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="ActivationReqWhiteBar" load_steps=2 format=3 uid="uid://reqwhitebar3card1"]
+
+[ext_resource type="Script" uid="uid://activationreqwhitebar1" path="res://Scripts/cards/ActivationReqWhiteBar.gd" id="1_req_white_bar_3"]
+
+[resource]
+script = ExtResource("1_req_white_bar_3")
+min_count = 3
+metadata/_custom_type_script = "uid://activationreqwhitebar1"

--- a/Scripts/cards/ActivationReqWhiteBar.gd
+++ b/Scripts/cards/ActivationReqWhiteBar.gd
@@ -1,0 +1,9 @@
+extends CardActivationReq
+class_name ActivationReqWhiteBar
+
+@export var min_count: int = 3
+
+func matches(round: RoundController, card: CardInstance, ctx: PatternContext) -> bool:
+	if round == null or round.state == null:
+		return false
+	return int(round.state.bar_white.size()) >= int(min_count)

--- a/Scripts/cards/ActivationReqWhiteBar.gd.uid
+++ b/Scripts/cards/ActivationReqWhiteBar.gd.uid
@@ -1,0 +1,1 @@
+uid://activationreqwhitebar1

--- a/Scripts/cards/effects/EffectJailbreak.gd
+++ b/Scripts/cards/effects/EffectJailbreak.gd
@@ -1,0 +1,10 @@
+extends CardEffect
+class_name EffectJailbreak
+
+func apply(round: RoundController, card: CardInstance, _ctx: PatternContext) -> void:
+	if round == null:
+		return
+	if round.has_method("activate_jailbreak"):
+		round.call("activate_jailbreak", card)
+	elif card != null:
+		round.emit_signal("card_consumed", card.uid)

--- a/Scripts/cards/effects/EffectJailbreak.gd.uid
+++ b/Scripts/cards/effects/EffectJailbreak.gd.uid
@@ -1,0 +1,1 @@
+uid://jailbreakeffect1

--- a/Scripts/core/rules/Rules.gd
+++ b/Scripts/core/rules/Rules.gd
@@ -19,6 +19,14 @@ static func _entry_point_from_bar(p: int, die: int) -> int:
 	# WHITE enters at 0..5 via die-1; BLACK enters at 23..18 via 24-die
 	return (die - 1) if p == BoardState.Player.WHITE else (24 - die)
 
+static func _entry_points_from_bar(state: BoardState, p: int, die: int) -> Array[int]:
+	var points: Array[int] = [_entry_point_from_bar(p, die)]
+	if p == BoardState.Player.WHITE and bool(state.jailbreak_white_active):
+		var jailbreak_point: int = 24 - die
+		if not points.has(jailbreak_point):
+			points.append(jailbreak_point)
+	return points
+
 static func _blocked_by_opponent(state: BoardState, p: int, dst: int) -> bool:
 	if dst < 0 or dst > 23:
 		return false
@@ -91,14 +99,15 @@ static func legal_moves_for_die(state: BoardState, p: int, die: int) -> Array[Di
 	if bar.size() > 0:
 		if not forward:
 			return res
-		var dst: int = _entry_point_from_bar(p, mag)
-		if not _blocked_by_opponent(state, p, dst):
-			var hit := _is_hit(state, p, dst)
+		for dst in _entry_points_from_bar(state, p, mag):
+			if _blocked_by_opponent(state, p, int(dst)):
+				continue
+			var hit := _is_hit(state, p, int(dst))
 			if _moving_checker_is_pacifism(state, p, -1) and hit:
 				return res
 			res.append({
 				"from": -1,
-				"to": dst,
+				"to": int(dst),
 				"hit": hit,
 			})
 		return res
@@ -173,14 +182,15 @@ static func legal_moves_for_die_adv(state: BoardState, p: int, die: int, bearoff
 	if bar.size() > 0:
 		if not forward:
 			return res
-		var dst: int = _entry_point_from_bar(p, mag)
-		if not _blocked_by_opponent(state, p, dst):
-			var hit := _is_hit(state, p, dst)
+		for dst in _entry_points_from_bar(state, p, mag):
+			if _blocked_by_opponent(state, p, int(dst)):
+				continue
+			var hit := _is_hit(state, p, int(dst))
 			if _moving_checker_is_pacifism(state, p, -1) and hit:
 				return res
 			res.append({
 				"from": -1,
-				"to": dst,
+				"to": int(dst),
 				"hit": hit,
 			})
 		return res

--- a/Scripts/core/state/BoardState.gd
+++ b/Scripts/core/state/BoardState.gd
@@ -15,6 +15,7 @@ var off_black: PackedInt32Array = PackedInt32Array()
 var turn: int = Player.WHITE
 var detente_turns_left: int = 0
 var friction_turns_left: int = 0
+var jailbreak_white_active: bool = false
 
 # ID registry
 var next_id: int = 1
@@ -66,6 +67,7 @@ func reset_standard() -> void:
 	turn = Player.WHITE
 	detente_turns_left = 0
 	friction_turns_left = 0
+	jailbreak_white_active = false
 
 	_spawn_stack(0, Player.WHITE, 2)
 	_spawn_stack(11, Player.WHITE, 5)

--- a/Scripts/game/RoundController.gd
+++ b/Scripts/game/RoundController.gd
@@ -3379,9 +3379,36 @@ func _on_debug_ai_enabled(enabled: bool) -> void:
 func _on_debug_point_delta(point_index: int, is_white: bool, delta: int) -> void:
 	if state == null:
 		return
-	if point_index < 0 or point_index > 23:
-		return
 	if delta == 0:
+		return
+
+	if point_index == -1 or point_index == -2:
+		var bar_owner: int = BoardState.Player.WHITE if point_index == -1 else BoardState.Player.BLACK
+		var bar_stack: PackedInt32Array = state.bar_white if bar_owner == BoardState.Player.WHITE else state.bar_black
+		if delta > 0:
+			for _i in range(delta):
+				var id := state.create_checker(bar_owner)
+				bar_stack.append(id)
+		else:
+			var remove_count := -delta
+			for _i in range(remove_count):
+				if bar_stack.is_empty():
+					break
+				var top_i := bar_stack.size() - 1
+				var id2 := bar_stack[top_i]
+				bar_stack.remove_at(top_i)
+				state.checkers.erase(id2)
+		if bar_owner == BoardState.Player.WHITE:
+			state.bar_white = bar_stack
+		else:
+			state.bar_black = bar_stack
+		if board != null and board.has_method("sync_from_state_full"):
+			board.call("sync_from_state_full", state)
+		selected_from = -999
+		_clear_targets()
+		return
+
+	if point_index < 0 or point_index > 23:
 		return
 
 	var owner: int = BoardState.Player.WHITE if is_white else BoardState.Player.BLACK

--- a/Scripts/game/RoundController.gd
+++ b/Scripts/game/RoundController.gd
@@ -581,6 +581,13 @@ func activate_rapid_retreat(card: CardInstance) -> void:
 	if card != null:
 		emit_signal("card_consumed", card.uid)
 
+func activate_jailbreak(card: CardInstance) -> void:
+	if state == null:
+		return
+	state.jailbreak_white_active = true
+	if card != null:
+		emit_signal("card_consumed", card.uid)
+
 func activate_momentum(card: CardInstance) -> void:
 	_momentum_active = true
 	_momentum_primary_pips = 1
@@ -1389,6 +1396,7 @@ func _black_ai_clone_state_for_sim(src: BoardState) -> BoardState:
 	c.off_black = src.off_black.duplicate()
 	c.detente_turns_left = int(src.detente_turns_left)
 	c.friction_turns_left = int(src.friction_turns_left)
+	c.jailbreak_white_active = bool(src.jailbreak_white_active)
 	return c
 
 func _apply_move_no_turn_end(die_used: int, move: Dictionary, player: int) -> void:


### PR DESCRIPTION
### Motivation
- Introduce a new tempo card `Jailbreak` that activates when White has 3+ checkers on the bar and grants an alternate re-entry option for the remainder of the round.
- Provide a pattern/activation requirement so the card is only usable in the intended board state (white-heavy bar).
- Wire the card into the gameplay systems so AI/simulation and UI can respect the new behavior.

### Description
- Added the `Jailbreak` card resource at `Resources/cards/tempo/jailbreak.tres` with art/pip metadata and an activation requirement resource `Resources/reqs/req_white_bar_3.tres` that references `ActivationReqWhiteBar.gd`.
- Implemented `ActivationReqWhiteBar` in `Scripts/cards/ActivationReqWhiteBar.gd` which returns true when `state.bar_white.size() >= min_count` (default 3).
- Added `EffectJailbreak` in `Scripts/cards/effects/EffectJailbreak.gd` which calls the new `activate_jailbreak` handler on the round controller.
- Tracked jailbreak state with `BoardState.jailbreak_white_active` and cleared it in `reset_standard`; propagated the flag when cloning state for AI sims in `_black_ai_clone_state_for_sim`.
- Extended entry-from-bar logic in `Scripts/core/rules/Rules.gd` by adding `_entry_points_from_bar(state, p, die)` and updating `legal_moves_for_die`/`legal_moves_for_die_adv` to consider the alternate white entry point when `jailbreak_white_active` is set.
- Added `activate_jailbreak` to `Scripts/game/RoundController.gd` which sets `state.jailbreak_white_active = true` and emits `card_consumed` to consume the card.
- Registered the new card in the catalog `Resources/cards/card_catalog.tres` so it appears with other tempo cards.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766b2d3c58832eb6b62feaf5bb09c9)