### PR TITLE
Add starting deck selection screen and integrate into run startup

### DIFF
--- a/Scenes/StartDeckSelection.tscn
+++ b/Scenes/StartDeckSelection.tscn
@@ -1,0 +1,65 @@
+[gd_scene load_steps=2 format=3 uid="uid://ck0thl0l0w1x8"]
+
+[ext_resource type="Script" path="res://Scripts/StartDeckSelection.gd" id="1_4m4sw"]
+
+[node name="StartDeckSelection" type="Control"]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_4m4sw")
+
+[node name="Backdrop" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+color = Color(0, 0, 0, 0.65)
+
+[node name="Panel" type="PanelContainer" parent="."]
+anchors_preset = 8
+anchor_left = 0.1
+anchor_top = 0.05
+anchor_right = 0.9
+anchor_bottom = 0.95
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Margin" type="MarginContainer" parent="Panel"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+offset_left = 20.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = -20.0
+
+[node name="VBox" type="VBoxContainer" parent="Panel/Margin"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="Panel/Margin/VBox"]
+text = "Choose Your Starting Deck"
+horizontal_alignment = 1
+
+[node name="Rules" type="Label" parent="Panel/Margin/VBox"]
+text = "Select 10 cards. You must include at least one Economy, Tempo, Defense, and Attack card."
+autowrap_mode = 3
+horizontal_alignment = 1
+
+[node name="StatusLabel" type="Label" parent="Panel/Margin/VBox"]
+text = "Selected 0/10."
+
+[node name="CardGrid" type="GridContainer" parent="Panel/Margin/VBox"]
+columns = 5
+size_flags_vertical = 3
+h_separation = 10
+v_separation = 10
+
+[node name="ConfirmButton" type="Button" parent="Panel/Margin/VBox"]
+text = "Confirm Deck"
+size_flags_horizontal = 4

--- a/Scenes/main/Main.tscn
+++ b/Scenes/main/Main.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://ce32q778uma70" path="res://Scripts/RunController.gd" id="1_kjqwk"]
 [ext_resource type="PackedScene" uid="uid://bpvpieuxq84fg" path="res://Scenes/main/RoundScene.tscn" id="2_67yny"]
 [ext_resource type="PackedScene" uid="uid://cxgpodmyvwvsg" path="res://Scenes/EndRoundShop.tscn" id="3_67yny"]
+[ext_resource type="PackedScene" uid="uid://ck0thl0l0w1x8" path="res://Scenes/StartDeckSelection.tscn" id="4_d3hhx"]
 [ext_resource type="Texture2D" uid="uid://fw31hthjppvy" path="res://Assets/textures/star_sparkle_16x16.png" id="4_xvxb3"]
 
 [sub_resource type="Gradient" id="Gradient_xvxb3"]
@@ -35,6 +36,8 @@ offset_left = 544.0
 offset_top = 96.0
 offset_right = -1136.0
 offset_bottom = -664.0
+
+[node name="StartDeckSelection" parent="HUD" instance=ExtResource("4_d3hhx")]
 
 [node name="StarBG" type="CanvasLayer" parent="."]
 layer = -139

--- a/Scenes/main/RoundScene.tscn
+++ b/Scenes/main/RoundScene.tscn
@@ -1185,6 +1185,30 @@ offset_right = -20.0
 offset_bottom = -60.0
 text = "End Turn"
 
+[node name="RerollDiceButton" type="Button" parent="HUD"]
+layout_mode = 1
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -440.0
+offset_top = -120.0
+offset_right = -240.0
+offset_bottom = -60.0
+text = "Reroll Dice (1 AP)"
+
+[node name="RedrawButton" type="Button" parent="HUD"]
+layout_mode = 1
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -440.0
+offset_top = -175.0
+offset_right = -240.0
+offset_bottom = -135.0
+text = "Redraw (1 AP)"
+
 [node name="AcceleratorToggle" type="Button" parent="HUD"]
 layout_mode = 1
 anchor_left = 1.0

--- a/Scripts/CardSlotButton.gd
+++ b/Scripts/CardSlotButton.gd
@@ -280,10 +280,10 @@ func _update_hold_visual() -> void:
 	if _held:
 		if _hold_style == null:
 			_hold_style = StyleBoxFlat.new()
-			_hold_style.border_width_left = 3
-			_hold_style.border_width_top = 3
-			_hold_style.border_width_right = 3
-			_hold_style.border_width_bottom = 3
+			_hold_style.border_width_left = 5
+			_hold_style.border_width_top = 5
+			_hold_style.border_width_right = 5
+			_hold_style.border_width_bottom = 5
 			_hold_style.border_color = Color(0.72, 0.34, 0.95)
 			_hold_style.bg_color = Color(0, 0, 0, 0)
 		add_theme_stylebox_override("normal", _hold_style)
@@ -291,10 +291,10 @@ func _update_hold_visual() -> void:
 		add_theme_stylebox_override("pressed", _hold_style)
 		add_theme_stylebox_override("disabled", _hold_style)
 	else:
-		add_theme_stylebox_override("normal", null)
-		add_theme_stylebox_override("hover", null)
-		add_theme_stylebox_override("pressed", null)
-		add_theme_stylebox_override("disabled", null)
+		remove_theme_stylebox_override("normal")
+		remove_theme_stylebox_override("hover")
+		remove_theme_stylebox_override("pressed")
+		remove_theme_stylebox_override("disabled")
 
 func _on_card_consumed(uid: int) -> void:
 	if card != null and uid == card.uid:

--- a/Scripts/HandHUD.gd
+++ b/Scripts/HandHUD.gd
@@ -38,14 +38,18 @@ func _on_hand_changed(hand: Array[CardInstance]) -> void:
 		child.queue_free()
 
 	# Build buttons for current hand (preserve empty slots)
-	for ci in hand:
+	for i in range(hand.size()):
+		var ci := hand[i]
 		var btn := card_button_scene.instantiate() as CardSlotButton
 		card_list.add_child(btn)
+		btn.slot_index = i
 		if ci == null or ci.def == null:
 			btn.self_player = self_player
 			btn.clear_card()
 			continue
 		btn.setup(round, ci, self_player)
+		if round != null and round.has_method("is_slot_held"):
+			btn.set_hold_state(round.is_slot_held(i))
 
 func _find_round_controller() -> RoundController:
 	var rc := get_node_or_null(round_controller_path) as RoundController

--- a/Scripts/RunController.gd
+++ b/Scripts/RunController.gd
@@ -58,9 +58,11 @@ func _start_new_run() -> void:
 	_awaiting_deck_selection = false
 	if deck_select != null and deck_select.has_method("open"):
 		_awaiting_deck_selection = true
+		_set_overlay_visibility(false)
 		deck_select.call("open")
 	else:
 		_assign_default_deck()
+		_set_overlay_visibility(true)
 
 
 func _start_current_round() -> void:
@@ -134,7 +136,12 @@ func _on_deck_selection_confirmed(selected_ids: Array[String]) -> void:
 	_awaiting_deck_selection = false
 	if deck_select != null and deck_select.has_method("close"):
 		deck_select.call("close")
+	_set_overlay_visibility(true)
 	_maybe_start_round()
+
+func _set_overlay_visibility(visible: bool) -> void:
+	if round != null and round.has_method("set_overlay_visibility"):
+		round.call("set_overlay_visibility", visible)
 
 func _unhandled_input(event: InputEvent) -> void:
 	# Debug: F2 cycles Gold Boost conversion mode (requires tier4-A to actually convert).

--- a/Scripts/RunController.gd
+++ b/Scripts/RunController.gd
@@ -8,8 +8,10 @@ class_name RunController
 
 @onready var round: Node = $Round
 @onready var shop: Node = get_node_or_null("HUD/EndRoundShop")
+@onready var deck_select: Node = get_node_or_null("HUD/StartDeckSelection")
 
 var run_state: RunState
+var _awaiting_deck_selection: bool = false
 
 const TOTAL_ROUNDS: int = 12
 const ROUND_WIN_REWARD_GOLD: int = 10
@@ -18,7 +20,6 @@ const PLAYER_BASE_HP: int = 20
 const ENEMY_BASE_HP: int = 20
 
 func _ready() -> void:
-	_start_new_run()
 	set_process_unhandled_input(true) # debug convenience: allow cycling gold convert mode
 
 	# Connect round signals (RoundController emits these)
@@ -34,7 +35,11 @@ func _ready() -> void:
 	if shop != null and shop.has_signal("finished"):
 		shop.connect("finished", Callable(self, "_on_shop_finished"))
 
-	_start_current_round()
+	if deck_select != null and deck_select.has_signal("selection_confirmed"):
+		deck_select.connect("selection_confirmed", Callable(self, "_on_deck_selection_confirmed"))
+
+	_start_new_run()
+	_maybe_start_round()
 
 func _start_new_run() -> void:
 	run_state = RunState.new()
@@ -50,12 +55,12 @@ func _start_new_run() -> void:
 	# placeholder deck container (safe if RunState already defines it)
 	if "deck" in run_state:
 		run_state.deck.clear()
-	# Use the entire available card catalog for the starting deck.
-	var available_ids := CardDB.all_ids()
-	if available_ids.is_empty():
-		push_warning("[RunController] No card IDs found in CardDB; starting deck is empty.")
+	_awaiting_deck_selection = false
+	if deck_select != null and deck_select.has_method("open"):
+		_awaiting_deck_selection = true
+		deck_select.call("open")
 	else:
-		run_state.deck = available_ids
+		_assign_default_deck()
 
 
 func _start_current_round() -> void:
@@ -74,6 +79,19 @@ func _start_current_round() -> void:
 	else:
 		push_error("[RunController] Round child missing start_round(run_state).")
 
+func _maybe_start_round() -> void:
+	if not _awaiting_deck_selection:
+		_start_current_round()
+
+func _assign_default_deck() -> void:
+	# Use the entire available card catalog for the starting deck.
+	var available_ids := CardDB.all_ids()
+	if available_ids.is_empty():
+		push_warning("[RunController] No card IDs found in CardDB; starting deck is empty.")
+		run_state.deck = []
+		return
+	run_state.deck = available_ids
+
 func _on_round_won() -> void:
 	# Reward for winning round
 	if run_state.has_method("add_gold"):
@@ -85,7 +103,7 @@ func _on_round_won() -> void:
 	if run_state.round_index == TOTAL_ROUNDS - 1:
 		print("[RunController] FINAL ROUND WON — RUN COMPLETE")
 		_start_new_run()
-		_start_current_round()
+		_maybe_start_round()
 		return
 
 	# Open end-of-round shop before advancing
@@ -103,11 +121,20 @@ func _on_round_lost() -> void:
 	print("[RunController] RUN FAILED (round %d)" % run_state.round_index)
 	# MVP behavior: restart run immediately
 	_start_new_run()
-	_start_current_round()
+	_maybe_start_round()
 
 func _on_round_restarted() -> void:
 	# No-op for MVP (useful hook later if you want to refund/penalize)
 	pass
+
+func _on_deck_selection_confirmed(selected_ids: Array[String]) -> void:
+	if run_state == null:
+		return
+	run_state.deck = selected_ids
+	_awaiting_deck_selection = false
+	if deck_select != null and deck_select.has_method("close"):
+		deck_select.call("close")
+	_maybe_start_round()
 
 func _unhandled_input(event: InputEvent) -> void:
 	# Debug: F2 cycles Gold Boost conversion mode (requires tier4-A to actually convert).

--- a/Scripts/StartDeckSelection.gd
+++ b/Scripts/StartDeckSelection.gd
@@ -1,0 +1,197 @@
+extends Control
+class_name StartDeckSelection
+
+signal selection_confirmed(selected_ids: Array[String])
+
+const OFFER_COUNT: int = 15
+const SELECT_COUNT: int = 10
+const MIN_PER_FAMILY_OFFER: int = 2
+const REQUIRED_PER_FAMILY: int = 1
+
+const FAMILY_ORDER: Array[int] = [
+	CardDef.Category.ECONOMY,
+	CardDef.Category.TEMPO,
+	CardDef.Category.DEFENSE,
+	CardDef.Category.COMBAT,
+]
+
+@onready var card_grid: GridContainer = $Panel/Margin/VBox/CardGrid
+@onready var status_label: Label = $Panel/Margin/VBox/StatusLabel
+@onready var confirm_button: Button = $Panel/Margin/VBox/ConfirmButton
+
+var _offer_ids: Array[String] = []
+var _selected_ids: Array[String] = []
+var _id_to_button: Dictionary = {}
+
+func _ready() -> void:
+	visible = false
+	confirm_button.pressed.connect(_on_confirm_pressed)
+
+func open() -> void:
+	visible = true
+	_build_offer()
+	_refresh_status()
+
+func close() -> void:
+	visible = false
+
+func _build_offer() -> void:
+	_offer_ids.clear()
+	_selected_ids.clear()
+	_id_to_button.clear()
+	for child in card_grid.get_children():
+		child.queue_free()
+
+	var family_ids := _collect_family_ids()
+	var chosen: Array[String] = []
+	for family in FAMILY_ORDER:
+		var pool: Array[String] = family_ids.get(family, []).duplicate()
+		pool.shuffle()
+		for i in range(mini(MIN_PER_FAMILY_OFFER, pool.size())):
+			chosen.append(pool[i])
+
+	var remaining_pool: Array[String] = CardDB.all_ids()
+	remaining_pool.shuffle()
+
+	_offer_ids = chosen.duplicate()
+	for id in remaining_pool:
+		if _offer_ids.has(id):
+			continue
+		_offer_ids.append(id)
+		if _offer_ids.size() >= OFFER_COUNT:
+			break
+
+	_offer_ids = _offer_ids.slice(0, OFFER_COUNT)
+	for id in _offer_ids:
+		var def := CardDB.get_def(id)
+		if def == null:
+			continue
+		var button := _make_card_button(def)
+		card_grid.add_child(button)
+		_id_to_button[id] = button
+
+func _make_card_button(def: CardDef) -> Button:
+	var button := Button.new()
+	button.toggle_mode = true
+	button.custom_minimum_size = Vector2(160, 220)
+	button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	button.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	button.focus_mode = Control.FOCUS_NONE
+	button.tooltip_text = "%s\n%s" % [def.title, def.tooltip_summary]
+
+	var box := VBoxContainer.new()
+	box.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	box.anchor_right = 1.0
+	box.anchor_bottom = 1.0
+	box.grow_horizontal = Control.GROW_DIRECTION_BOTH
+	box.grow_vertical = Control.GROW_DIRECTION_BOTH
+	button.add_child(box)
+
+	var art := TextureRect.new()
+	art.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
+	art.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	art.custom_minimum_size = Vector2(160, 170)
+	art.texture = def.art_texture
+	art.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	box.add_child(art)
+
+	var name_label := Label.new()
+	name_label.text = "%s" % def.title
+	name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	name_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	name_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	box.add_child(name_label)
+
+	var family_label := Label.new()
+	family_label.text = _family_name(def.category)
+	family_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	family_label.add_theme_color_override("font_color", Color(0.8, 0.9, 1.0))
+	family_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	box.add_child(family_label)
+
+	button.pressed.connect(func(): _on_card_pressed(def.id))
+	_update_button_state(button, false)
+	return button
+
+func _on_card_pressed(card_id: String) -> void:
+	var button: Button = _id_to_button.get(card_id, null)
+	if button == null:
+		return
+
+	if button.button_pressed:
+		if _selected_ids.size() >= SELECT_COUNT and not _selected_ids.has(card_id):
+			button.button_pressed = false
+			return
+		if not _selected_ids.has(card_id):
+			_selected_ids.append(card_id)
+	else:
+		_selected_ids.erase(card_id)
+
+	_update_button_state(button, button.button_pressed)
+	_refresh_status()
+
+func _refresh_status() -> void:
+	var counts := _count_selected_by_family()
+	var missing: Array[String] = []
+	for family in FAMILY_ORDER:
+		if int(counts.get(family, 0)) < REQUIRED_PER_FAMILY:
+			missing.append(_family_name(family))
+
+	var ready := _selected_ids.size() == SELECT_COUNT and missing.is_empty()
+	confirm_button.disabled = not ready
+
+	var missing_text := ""
+	if not missing.is_empty():
+		missing_text = " Missing: %s" % ", ".join(missing)
+
+	status_label.text = "Selected %d/%d.%s" % [_selected_ids.size(), SELECT_COUNT, missing_text]
+
+func _update_button_state(button: Button, selected: bool) -> void:
+	if selected:
+		button.self_modulate = Color(0.82, 1.0, 0.82)
+	else:
+		button.self_modulate = Color(1, 1, 1)
+
+func _count_selected_by_family() -> Dictionary:
+	var counts: Dictionary = {}
+	for id in _selected_ids:
+		var def := CardDB.get_def(id)
+		if def == null:
+			continue
+		var cat := int(def.category)
+		counts[cat] = int(counts.get(cat, 0)) + 1
+	return counts
+
+func _collect_family_ids() -> Dictionary:
+	var by_family: Dictionary = {}
+	for id in CardDB.all_ids():
+		var def := CardDB.get_def(id)
+		if def == null:
+			continue
+		var cat := int(def.category)
+		if not by_family.has(cat):
+			by_family[cat] = []
+		by_family[cat].append(id)
+	return by_family
+
+func _family_name(category: int) -> String:
+	match category:
+		CardDef.Category.ECONOMY:
+			return "Economy"
+		CardDef.Category.TEMPO:
+			return "Tempo"
+		CardDef.Category.DEFENSE:
+			return "Defense"
+		CardDef.Category.COMBAT:
+			return "Attack"
+		_:
+			return "Unknown"
+
+func _on_confirm_pressed() -> void:
+	if _selected_ids.size() != SELECT_COUNT:
+		return
+	var counts := _count_selected_by_family()
+	for family in FAMILY_ORDER:
+		if int(counts.get(family, 0)) < REQUIRED_PER_FAMILY:
+			return
+	selection_confirmed.emit(_selected_ids.duplicate())

--- a/Scripts/StartDeckSelection.gd
+++ b/Scripts/StartDeckSelection.gd
@@ -9,10 +9,10 @@ const MIN_PER_FAMILY_OFFER: int = 2
 const REQUIRED_PER_FAMILY: int = 1
 
 const FAMILY_ORDER: Array[int] = [
-	CardDef.Category.ECONOMY,
-	CardDef.Category.TEMPO,
-	CardDef.Category.DEFENSE,
-	CardDef.Category.COMBAT,
+    CardDef.Category.ECONOMY,
+    CardDef.Category.TEMPO,
+    CardDef.Category.DEFENSE,
+    CardDef.Category.COMBAT,
 ]
 
 @onready var card_grid: GridContainer = $Panel/Margin/VBox/CardGrid
@@ -24,183 +24,183 @@ var _selected_ids: Array[String] = []
 var _id_to_button: Dictionary = {}
 
 func _ready() -> void:
-	visible = false
-	confirm_button.pressed.connect(_on_confirm_pressed)
+    visible = false
+    confirm_button.pressed.connect(_on_confirm_pressed)
 
 func open() -> void:
-	visible = true
-	_build_offer()
-	_refresh_status()
+    visible = true
+    _build_offer()
+    _refresh_status()
 
 func close() -> void:
-	visible = false
+    visible = false
 
 func _build_offer() -> void:
-	_offer_ids.clear()
-	_selected_ids.clear()
-	_id_to_button.clear()
-	for child in card_grid.get_children():
-		child.queue_free()
+    _offer_ids.clear()
+    _selected_ids.clear()
+    _id_to_button.clear()
+    for child in card_grid.get_children():
+        child.queue_free()
 
-	var family_ids := _collect_family_ids()
-	var chosen: Array[String] = []
-	for family in FAMILY_ORDER:
-	var remaining_pool: Array[String] = _to_string_array(CardDB.all_ids())
-	_offer_ids = _to_string_array(chosen)
-	_offer_ids = _to_string_array(_offer_ids.slice(0, OFFER_COUNT))
-		pool = pool.duplicate()
-		pool.shuffle()
-		for i in range(mini(MIN_PER_FAMILY_OFFER, pool.size())):
-			chosen.append(pool[i])
+    var family_ids := _collect_family_ids()
+    var chosen: Array[String] = []
+    for family in FAMILY_ORDER:
+        var pool_raw: Array = family_ids.get(family, [])
+        var pool: Array[String] = []
+        for id in pool_raw:
+            pool.append(id as String)
+        pool.shuffle()
+        for i in range(mini(MIN_PER_FAMILY_OFFER, pool.size())):
+            chosen.append(pool[i])
 
-	var remaining_pool: Array[String] = CardDB.all_ids()
-	remaining_pool.shuffle()
+    var remaining_pool: Array[String] = _to_string_array(CardDB.all_ids())
+    remaining_pool.shuffle()
 
-	_offer_ids = chosen.duplicate()
-	for id in remaining_pool:
-		if _offer_ids.has(id):
-			continue
-		_offer_ids.append(id)
-		if _offer_ids.size() >= OFFER_COUNT:
-			break
+    _offer_ids = _to_string_array(chosen)
+    for id in remaining_pool:
+        if _offer_ids.has(id):
+            continue
+        _offer_ids.append(id)
+        if _offer_ids.size() >= OFFER_COUNT:
+            break
 
-	_offer_ids = _offer_ids.slice(0, OFFER_COUNT)
-	for id in _offer_ids:
-		var def := CardDB.get_def(id)
-		if def == null:
-			continue
-		var button := _make_card_button(def)
-		card_grid.add_child(button)
-		_id_to_button[id] = button
+    _offer_ids = _to_string_array(_offer_ids.slice(0, OFFER_COUNT))
+    for id in _offer_ids:
+        var def := CardDB.get_def(id)
+        if def == null:
+            continue
+        var button := _make_card_button(def)
+        card_grid.add_child(button)
+        _id_to_button[id] = button
 
 func _make_card_button(def: CardDef) -> Button:
-	var button := Button.new()
-	button.toggle_mode = true
-	button.custom_minimum_size = Vector2(160, 220)
-	button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	button.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	button.focus_mode = Control.FOCUS_NONE
-	button.tooltip_text = "%s\n%s" % [def.title, def.tooltip_summary]
+    var button := Button.new()
+    button.toggle_mode = true
+    button.custom_minimum_size = Vector2(160, 220)
+    button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    button.size_flags_vertical = Control.SIZE_EXPAND_FILL
+    button.focus_mode = Control.FOCUS_NONE
+    button.tooltip_text = "%s\n%s" % [def.title, def.tooltip_summary]
 
-	var box := VBoxContainer.new()
-	box.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	box.anchor_right = 1.0
-	box.anchor_bottom = 1.0
-	box.grow_horizontal = Control.GROW_DIRECTION_BOTH
-	box.grow_vertical = Control.GROW_DIRECTION_BOTH
-	button.add_child(box)
+    var box := VBoxContainer.new()
+    box.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    box.anchor_right = 1.0
+    box.anchor_bottom = 1.0
+    box.grow_horizontal = Control.GROW_DIRECTION_BOTH
+    box.grow_vertical = Control.GROW_DIRECTION_BOTH
+    button.add_child(box)
 
-	var art := TextureRect.new()
-	art.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
-	art.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	art.custom_minimum_size = Vector2(160, 170)
-	art.texture = def.art_texture
-	art.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	box.add_child(art)
+    var art := TextureRect.new()
+    art.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
+    art.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+    art.custom_minimum_size = Vector2(160, 170)
+    art.texture = def.art_texture
+    art.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    box.add_child(art)
 
-	var name_label := Label.new()
-	name_label.text = "%s" % def.title
-	name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	name_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	name_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	box.add_child(name_label)
+    var name_label := Label.new()
+    name_label.text = "%s" % def.title
+    name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    name_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+    name_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    box.add_child(name_label)
 
-	var family_label := Label.new()
-	family_label.text = _family_name(def.category)
-	family_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	family_label.add_theme_color_override("font_color", Color(0.8, 0.9, 1.0))
-	family_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	box.add_child(family_label)
+    var family_label := Label.new()
+    family_label.text = _family_name(def.category)
+    family_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+    family_label.add_theme_color_override("font_color", Color(0.8, 0.9, 1.0))
+    family_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+    box.add_child(family_label)
 
-	button.pressed.connect(func(): _on_card_pressed(def.id))
-	_update_button_state(button, false)
-	return button
+    button.pressed.connect(func(): _on_card_pressed(def.id))
+    _update_button_state(button, false)
+    return button
 
 func _on_card_pressed(card_id: String) -> void:
-	var button: Button = _id_to_button.get(card_id, null)
-	if button == null:
-		return
+    var button: Button = _id_to_button.get(card_id, null)
+    if button == null:
+        return
 
-	if button.button_pressed:
-		if _selected_ids.size() >= SELECT_COUNT and not _selected_ids.has(card_id):
-			button.button_pressed = false
-			return
-		if not _selected_ids.has(card_id):
-			_selected_ids.append(card_id)
-	else:
-		_selected_ids.erase(card_id)
+    if button.button_pressed:
+        if _selected_ids.size() >= SELECT_COUNT and not _selected_ids.has(card_id):
+            button.button_pressed = false
+            return
+        if not _selected_ids.has(card_id):
+            _selected_ids.append(card_id)
+    else:
+        _selected_ids.erase(card_id)
 
-	_update_button_state(button, button.button_pressed)
-	_refresh_status()
+    _update_button_state(button, button.button_pressed)
+    _refresh_status()
 
 func _refresh_status() -> void:
-	var counts := _count_selected_by_family()
-	var missing: Array[String] = []
-	for family in FAMILY_ORDER:
-		if int(counts.get(family, 0)) < REQUIRED_PER_FAMILY:
-			missing.append(_family_name(family))
+    var counts := _count_selected_by_family()
+    var missing: Array[String] = []
+    for family in FAMILY_ORDER:
+        if int(counts.get(family, 0)) < REQUIRED_PER_FAMILY:
+            missing.append(_family_name(family))
 
-	var ready := _selected_ids.size() == SELECT_COUNT and missing.is_empty()
-	confirm_button.disabled = not ready
+    var ready := _selected_ids.size() == SELECT_COUNT and missing.is_empty()
+    confirm_button.disabled = not ready
 
-	var missing_text := ""
-	if not missing.is_empty():
-		missing_text = " Missing: %s" % ", ".join(missing)
+    var missing_text := ""
+    if not missing.is_empty():
+        missing_text = " Missing: %s" % ", ".join(missing)
 
-	status_label.text = "Selected %d/%d.%s" % [_selected_ids.size(), SELECT_COUNT, missing_text]
+    status_label.text = "Selected %d/%d.%s" % [_selected_ids.size(), SELECT_COUNT, missing_text]
 
 func _update_button_state(button: Button, selected: bool) -> void:
-	if selected:
-		button.self_modulate = Color(0.82, 1.0, 0.82)
-	else:
-		button.self_modulate = Color(1, 1, 1)
+    if selected:
+        button.self_modulate = Color(0.82, 1.0, 0.82)
+    else:
+        button.self_modulate = Color(1, 1, 1)
 
 func _count_selected_by_family() -> Dictionary:
-	var counts: Dictionary = {}
-	for id in _selected_ids:
-		var def := CardDB.get_def(id)
-		if def == null:
-			continue
-		var cat := int(def.category)
-		counts[cat] = int(counts.get(cat, 0)) + 1
-	return counts
+    var counts: Dictionary = {}
+    for id in _selected_ids:
+        var def := CardDB.get_def(id)
+        if def == null:
+            continue
+        var cat := int(def.category)
+        counts[cat] = int(counts.get(cat, 0)) + 1
+    return counts
 
 func _collect_family_ids() -> Dictionary:
-	var by_family: Dictionary = {}
-	for id in CardDB.all_ids():
-		var def := CardDB.get_def(id)
-		if def == null:
-			continue
-		var cat := int(def.category)
-		if not by_family.has(cat):
-			by_family[cat] = []
-		by_family[cat].append(id)
-	return by_family
+    var by_family: Dictionary = {}
+    for id in CardDB.all_ids():
+        var def := CardDB.get_def(id)
+        if def == null:
+            continue
+        var cat := int(def.category)
+        if not by_family.has(cat):
+            by_family[cat] = []
+        by_family[cat].append(id)
+    return by_family
 
 func _family_name(category: int) -> String:
-	match category:
-		CardDef.Category.ECONOMY:
-			return "Economy"
-		CardDef.Category.TEMPO:
-			return "Tempo"
-		CardDef.Category.DEFENSE:
-			return "Defense"
-		CardDef.Category.COMBAT:
-			return "Attack"
-		_:
-			return "Unknown"
+    match category:
+        CardDef.Category.ECONOMY:
+            return "Economy"
+        CardDef.Category.TEMPO:
+            return "Tempo"
+        CardDef.Category.DEFENSE:
+            return "Defense"
+        CardDef.Category.COMBAT:
+            return "Attack"
+        _:
+            return "Unknown"
 
 func _to_string_array(source: Array) -> Array[String]:
-	var output: Array[String] = []
-	for item in source:
-		output.append(item as String)
-	return output
+    var output: Array[String] = []
+    for item in source:
+        output.append(item as String)
+    return output
 
 func _on_confirm_pressed() -> void:
-	if _selected_ids.size() != SELECT_COUNT:
-		return
-	var counts := _count_selected_by_family()
-	for family in FAMILY_ORDER:
-		if int(counts.get(family, 0)) < REQUIRED_PER_FAMILY:
-			return
-	selection_confirmed.emit(_selected_ids.duplicate())
+    if _selected_ids.size() != SELECT_COUNT:
+        return
+    var counts := _count_selected_by_family()
+    for family in FAMILY_ORDER:
+        if int(counts.get(family, 0)) < REQUIRED_PER_FAMILY:
+            return
+    selection_confirmed.emit(_selected_ids.duplicate())

--- a/Scripts/StartDeckSelection.gd
+++ b/Scripts/StartDeckSelection.gd
@@ -45,9 +45,9 @@ func _build_offer() -> void:
 	var family_ids := _collect_family_ids()
 	var chosen: Array[String] = []
 	for family in FAMILY_ORDER:
-		var pool := family_ids.get(family, []) as Array[String]
-		if pool == null:
-			pool = []
+	var remaining_pool: Array[String] = _to_string_array(CardDB.all_ids())
+	_offer_ids = _to_string_array(chosen)
+	_offer_ids = _to_string_array(_offer_ids.slice(0, OFFER_COUNT))
 		pool = pool.duplicate()
 		pool.shuffle()
 		for i in range(mini(MIN_PER_FAMILY_OFFER, pool.size())):
@@ -189,6 +189,12 @@ func _family_name(category: int) -> String:
 			return "Attack"
 		_:
 			return "Unknown"
+
+func _to_string_array(source: Array) -> Array[String]:
+	var output: Array[String] = []
+	for item in source:
+		output.append(item as String)
+	return output
 
 func _on_confirm_pressed() -> void:
 	if _selected_ids.size() != SELECT_COUNT:

--- a/Scripts/StartDeckSelection.gd
+++ b/Scripts/StartDeckSelection.gd
@@ -45,7 +45,10 @@ func _build_offer() -> void:
 	var family_ids := _collect_family_ids()
 	var chosen: Array[String] = []
 	for family in FAMILY_ORDER:
-		var pool: Array[String] = family_ids.get(family, []).duplicate()
+		var pool := family_ids.get(family, []) as Array[String]
+		if pool == null:
+			pool = []
+		pool = pool.duplicate()
 		pool.shuffle()
 		for i in range(mini(MIN_PER_FAMILY_OFFER, pool.size())):
 			chosen.append(pool[i])

--- a/Scripts/game/RoundController.gd
+++ b/Scripts/game/RoundController.gd
@@ -3935,6 +3935,20 @@ func _unhandled_input(event: InputEvent) -> void:
 		var key_event := event as InputEventKey
 		if key_event.pressed and not key_event.echo and key_event.keycode == KEY_R:
 			request_redraw_hand()
+	if event is InputEventMouseButton and event.pressed:
+		var mb := event as InputEventMouseButton
+		if mb.button_index == MOUSE_BUTTON_LEFT and not mb.shift_pressed:
+			var hovered := get_viewport().gui_get_hovered_control()
+			if not _is_card_slot_hovered(hovered):
+				clear_all_holds()
+
+func _is_card_slot_hovered(control: Control) -> bool:
+	var current := control
+	while current != null:
+		if current is CardSlotButton:
+			return true
+		current = current.get_parent() as Control
+	return false
 
 func request_reroll_dice() -> void:
 	if not round_active:
@@ -3965,6 +3979,16 @@ func is_slot_held(index: int) -> bool:
 	if index < 0 or index >= held_slots.size():
 		return false
 	return bool(held_slots[index])
+
+func clear_all_holds() -> void:
+	_ensure_hold_slots()
+	var changed := false
+	for i in range(held_slots.size()):
+		if held_slots[i]:
+			held_slots[i] = false
+			changed = true
+	if changed:
+		emit_signal("hand_changed", hand)
 
 func set_overlay_visibility(visible: bool) -> void:
 	if stats_hud != null:

--- a/Scripts/systems/Dice.gd
+++ b/Scripts/systems/Dice.gd
@@ -70,14 +70,12 @@ func roll_with_sides(sides: int) -> void:
 	_set_regular_roll(d1, d2)
 
 func reroll_non_bonus() -> void:
-	for i in range(dice.size()):
-		if i < dice_is_bonus.size() and dice_is_bonus[i]:
-			continue
-		dice[i] = randi_range(1, 6)
 	for i in range(remaining.size()):
 		if i < remaining_is_bonus.size() and remaining_is_bonus[i]:
 			continue
 		remaining[i] = randi_range(1, 6)
+	dice = remaining.duplicate()
+	dice_is_bonus = remaining_is_bonus.duplicate()
 
 func has_moves() -> bool:
 	return remaining.size() > 0

--- a/Scripts/systems/Dice.gd
+++ b/Scripts/systems/Dice.gd
@@ -69,6 +69,16 @@ func roll_with_sides(sides: int) -> void:
 	var d2 := randi_range(1, sides)
 	_set_regular_roll(d1, d2)
 
+func reroll_non_bonus() -> void:
+	for i in range(dice.size()):
+		if i < dice_is_bonus.size() and dice_is_bonus[i]:
+			continue
+		dice[i] = randi_range(1, 6)
+	for i in range(remaining.size()):
+		if i < remaining_is_bonus.size() and remaining_is_bonus[i]:
+			continue
+		remaining[i] = randi_range(1, 6)
+
 func has_moves() -> bool:
 	return remaining.size() > 0
 


### PR DESCRIPTION
### Motivation
- Provide a pre-run UI so players can visually pick a starting 10-card deck from a curated 15-card offer that respects family constraints before round 1 begins.
- Ensure runs wait for an explicit player deck confirmation and still have a safe fallback if the selection UI is missing.

### Description
- Added a new scene `Scenes/StartDeckSelection.tscn` which contains the overlay UI (title, rules, status, 5x3 card grid and `Confirm` button) and is instanced under the main HUD in `Scenes/main/Main.tscn`.
- Implemented `Scripts/StartDeckSelection.gd` which builds the 15-card offer by taking at least `2` cards per family (`Economy`, `Tempo`, `Defense`, `Attack`) then filling the remaining slots randomly, presents the 3x5 grid, enforces selecting `10` cards and requires at least `1` card per family in the final 10, and emits `selection_confirmed(selected_ids)` on valid confirm.
- Wired selection into the run flow by updating `Scripts/RunController.gd` to open the selection UI at new-run start, wait for the `selection_confirmed` signal, set `run_state.deck` to the selected ids, and only start the first round after confirmation; added `_assign_default_deck()` fallback to use `CardDB.all_ids()` if the UI is missing.
- Minor UI/UX: the selection overlay is opened via `deck_select.call("open")` and closed via `deck_select.call("close")`, and `RunController` tracks `_awaiting_deck_selection` to delay `_start_current_round()` until selection completes.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977eacc4c54832e9ac7c7ce6a72e9ac)