### PR TITLE
Add DeckStatusHUD overlay and D-key toggle to view deck/discard

### DIFF
--- a/Scenes/DeckStatusHUD.tscn
+++ b/Scenes/DeckStatusHUD.tscn
@@ -1,0 +1,81 @@
+[gd_scene load_steps=2 format=3 uid="uid://deck_status_hud"]
+
+[ext_resource type="Script" path="res://Scripts/DeckStatusHUD.gd" id="1_2s7lq"]
+
+[node name="DeckStatusHUD" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_2s7lq")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+offset_left = 160.0
+offset_top = 120.0
+offset_right = -160.0
+offset_bottom = -120.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+offset_left = 16.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = -16.0
+
+[node name="VBox" type="VBoxContainer" parent="Panel/MarginContainer"]
+layout_mode = 1
+anchors_preset = 15
+
+[node name="Title" type="Label" parent="Panel/MarginContainer/VBox"]
+layout_mode = 2
+text = "Deck & Discard (Press D to close)"
+
+[node name="Columns" type="HBoxContainer" parent="Panel/MarginContainer/VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_horizontal = 3
+alignment = 0
+theme_override_constants/separation = 24
+
+[node name="Discard" type="VBoxContainer" parent="Panel/MarginContainer/VBox/Columns"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DiscardHeader" type="Label" parent="Panel/MarginContainer/VBox/Columns/Discard"]
+layout_mode = 2
+text = "Discard Pile"
+
+[node name="Scroll" type="ScrollContainer" parent="Panel/MarginContainer/VBox/Columns/Discard"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DiscardText" type="RichTextLabel" parent="Panel/MarginContainer/VBox/Columns/Discard/Scroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "(empty)"
+
+[node name="Draw" type="VBoxContainer" parent="Panel/MarginContainer/VBox/Columns"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DrawHeader" type="Label" parent="Panel/MarginContainer/VBox/Columns/Draw"]
+layout_mode = 2
+text = "Draw Pile"
+
+[node name="Scroll" type="ScrollContainer" parent="Panel/MarginContainer/VBox/Columns/Draw"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DrawText" type="RichTextLabel" parent="Panel/MarginContainer/VBox/Columns/Draw/Scroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "(empty)"

--- a/Scenes/main/RoundScene.tscn
+++ b/Scenes/main/RoundScene.tscn
@@ -13,6 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://bqyhhs7nso515" path="res://Scenes/StatsHUD.tscn" id="10_e87vp"]
 [ext_resource type="PackedScene" uid="uid://cxgpodmyvwvsg" path="res://Scenes/EndRoundShop.tscn" id="11_black_market"]
 [ext_resource type="PackedScene" uid="uid://c5ou1koxgc3o1" path="res://Scenes/AuxCardsHUD.tscn" id="11_k0kue"]
+[ext_resource type="PackedScene" uid="uid://deck_status_hud" path="res://Scenes/DeckStatusHUD.tscn" id="12_deck_status"]
 [ext_resource type="Script" uid="uid://umoarpkqrdyf" path="res://SkillTreeManager.gd" id="12_k0kue"]
 [ext_resource type="Script" uid="uid://bnoikb2cewgg" path="res://Scripts/ai/AIController.gd" id="14_vwgvb"]
 [ext_resource type="Script" uid="uid://31vcv7leafq1" path="res://Scripts/ai/AIConfig.gd" id="15_bvjbw"]
@@ -1260,6 +1261,9 @@ offset_top = 650.0
 offset_right = 1540.0
 offset_bottom = 690.0
 scale = Vector2(1.16, 1.16)
+
+[node name="DeckStatusHUD" parent="HUD" instance=ExtResource("12_deck_status")]
+z_index = 50
 
 [node name="DebugMenu" parent="." instance=ExtResource("8_b8mt7")]
 offset = Vector2(1505.251, 500)

--- a/Scripts/DeckStatusHUD.gd
+++ b/Scripts/DeckStatusHUD.gd
@@ -1,0 +1,90 @@
+extends Control
+class_name DeckStatusHUD
+
+@export var round_controller_path: NodePath = NodePath("../..")
+@export var poll_interval: float = 0.2
+
+@onready var discard_header: Label = $Panel/MarginContainer/VBox/Columns/Discard/DiscardHeader
+@onready var draw_header: Label = $Panel/MarginContainer/VBox/Columns/Draw/DrawHeader
+@onready var discard_text: RichTextLabel = $Panel/MarginContainer/VBox/Columns/Discard/Scroll/DiscardText
+@onready var draw_text: RichTextLabel = $Panel/MarginContainer/VBox/Columns/Draw/Scroll/DrawText
+
+var _round: RoundController = null
+var _accum: float = 0.0
+
+func _ready() -> void:
+	_round = get_node_or_null(round_controller_path) as RoundController
+	if _round == null:
+		push_error("[DeckStatusHUD] Could not find RoundController at: " + str(round_controller_path))
+	visible = false
+
+func _process(delta: float) -> void:
+	if not visible:
+		return
+	_accum += delta
+	if _accum < poll_interval:
+		return
+	_accum = 0.0
+	_refresh()
+
+func toggle() -> void:
+	if visible:
+		close()
+	else:
+		open()
+
+func open() -> void:
+	visible = true
+	_accum = 0.0
+	_refresh()
+
+func close() -> void:
+	visible = false
+
+func _refresh() -> void:
+	if _round == null:
+		return
+
+	var discard_list: Array[String] = _round.discard_pile.duplicate()
+	var draw_list: Array[String] = _round.draw_pile.duplicate()
+
+	discard_header.text = "Discard Pile (%d)" % discard_list.size()
+	draw_header.text = "Draw Pile (%d)" % draw_list.size()
+
+	discard_text.text = _format_counts(_count_cards(discard_list))
+	draw_text.text = _format_counts(_count_cards(draw_list))
+
+func _count_cards(card_ids: Array[String]) -> Dictionary:
+	var counts: Dictionary = {}
+	for id in card_ids:
+		var key := String(id)
+		counts[key] = int(counts.get(key, 0)) + 1
+	return counts
+
+func _format_counts(counts: Dictionary) -> String:
+	if counts.is_empty():
+		return "(empty)"
+
+	var entries: Array[Dictionary] = []
+	for id in counts.keys():
+		var def := CardDB.get_def(String(id))
+		var name := def.title if def != null and def.title != "" else String(id)
+		entries.append({"name": name, "id": String(id), "count": int(counts[id])})
+
+	entries.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		var name_a: String = a["name"]
+		var name_b: String = b["name"]
+		if name_a == name_b:
+			return String(a["id"]) < String(b["id"])
+		return name_a < name_b
+	)
+
+	var lines: Array[String] = []
+	for entry in entries:
+		var count: int = int(entry["count"])
+		var label: String = entry["name"]
+		if count > 1:
+			label = "%s x%d" % [label, count]
+		lines.append(label)
+
+	return "\n".join(lines)

--- a/Scripts/game/RoundController.gd
+++ b/Scripts/game/RoundController.gd
@@ -54,6 +54,7 @@ var aux_used_this_turn: Dictionary = {}  # aux_id -> bool (per WHITE turn)
 @onready var debug_menu: DebugMenu = get_node_or_null("DebugMenu") as DebugMenu
 @onready var stats_hud: Node = get_node_or_null("HUD/StatsHUD")
 @onready var aux_cards_hud: Node = get_node_or_null("HUD/AuxCardsHUD")
+@onready var deck_status_hud: Node = get_node_or_null("HUD/DeckStatusHUD")
 
 # --- Skill tree wiring (MVP) ---
 @onready var skill_tree: SkillTreeManager = get_node_or_null("SkillTreeManager") as SkillTreeManager
@@ -3933,8 +3934,12 @@ func request_redraw_hand() -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventKey:
 		var key_event := event as InputEventKey
-		if key_event.pressed and not key_event.echo and key_event.keycode == KEY_R:
-			request_redraw_hand()
+		if key_event.pressed and not key_event.echo:
+			if key_event.keycode == KEY_R:
+				request_redraw_hand()
+			elif key_event.keycode == KEY_D:
+				if deck_status_hud != null and deck_status_hud.has_method("toggle"):
+					deck_status_hud.call("toggle")
 	if event is InputEventMouseButton and event.pressed:
 		var mb := event as InputEventMouseButton
 		if mb.button_index == MOUSE_BUTTON_LEFT and not mb.shift_pressed:


### PR DESCRIPTION
### Motivation
- Provide a quick in-game HUD to inspect which card IDs are in the discard pile and which remain in the draw pile, and allow closing it with the same key.

### Description
- Added a new HUD scene `Scenes/DeckStatusHUD.tscn` and controller `Scripts/DeckStatusHUD.gd` that shows counts and human-friendly names for the `discard_pile` and `draw_pile` and formats duplicate counts (e.g., `Card Title x2`).
- Instantiated the HUD under the main `HUD` in `Scenes/main/RoundScene.tscn` and gave it a high `z_index` so it overlays the UI.
- Wired a reference `deck_status_hud` in `Scripts/game/RoundController.gd` and updated `_unhandled_input` to toggle the overlay on `KEY_D` (keeps existing `R` redraw behavior intact).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69791dd3a948832e9ac3cc31d6972f2a)