### PR TITLE
Reposition hand HUD beneath board, switch to horizontal layout, and add 5th card slot

### DIFF
--- a/Scenes/main/RoundScene.tscn
+++ b/Scenes/main/RoundScene.tscn
@@ -1114,7 +1114,7 @@ metadata/_custom_type_script = "uid://c2qiglxxxkfbj"
 
 [node name="RoundController" type="Node"]
 script = ExtResource("1_137o6")
-hand_size = 4
+hand_size = 5
 base_ap_per_turn = 3
 ai_step_delay_sec = 2.0
 
@@ -1132,13 +1132,15 @@ scale = Vector2(1, 1)
 [node name="HUD" type="CanvasLayer" parent="."]
 
 [node name="HandHUD" type="Control" parent="HUD"]
-custom_minimum_size = Vector2(160, 220)
+custom_minimum_size = Vector2(900, 250)
 layout_mode = 3
-anchors_preset = 0
-offset_left = 1330.0
-offset_top = 15.0
-offset_right = 1434.0
-offset_bottom = 118.0
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -250.0
+grow_horizontal = 2
+grow_vertical = 0
 theme = SubResource("Theme_xdnbs")
 script = ExtResource("8_xdnbs")
 round_controller_path = NodePath("../..")
@@ -1146,21 +1148,35 @@ card_list_path = NodePath("Panel/MarginContainer/CardList")
 card_button_scene = ExtResource("5_g7xfr")
 
 [node name="Panel" type="Panel" parent="HUD/HandHUD"]
-layout_mode = 0
-offset_right = 131.78296
-offset_bottom = 226.0
-scale = Vector2(0.97, 0.97)
+custom_minimum_size = Vector2(860, 236)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -430.0
+offset_top = -118.0
+offset_right = 430.0
+offset_bottom = 118.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_g7xfr")
 
 [node name="MarginContainer" type="MarginContainer" parent="HUD/HandHUD/Panel"]
-layout_mode = 0
-offset_right = 100.0
-offset_bottom = 100.3
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 18.0
+offset_top = 8.0
+offset_right = -18.0
+offset_bottom = -8.0
 
-[node name="CardList" type="VBoxContainer" parent="HUD/HandHUD/Panel/MarginContainer"]
+[node name="CardList" type="HBoxContainer" parent="HUD/HandHUD/Panel/MarginContainer"]
 layout_mode = 2
 theme = SubResource("Theme_g7xfr")
-theme_override_constants/separation = 50
+theme_override_constants/separation = 12
 
 [node name="DiceUI" type="Control" parent="HUD"]
 layout_mode = 3

--- a/Scripts/game/RoundController.gd
+++ b/Scripts/game/RoundController.gd
@@ -55,6 +55,7 @@ var aux_used_this_turn: Dictionary = {}  # aux_id -> bool (per WHITE turn)
 @onready var stats_hud: Node = get_node_or_null("HUD/StatsHUD")
 @onready var aux_cards_hud: Node = get_node_or_null("HUD/AuxCardsHUD")
 @onready var deck_status_hud: Node = get_node_or_null("HUD/DeckStatusHUD")
+@onready var hand_hud: Control = get_node_or_null("HUD/HandHUD") as Control
 
 # --- Skill tree wiring (MVP) ---
 @onready var skill_tree: SkillTreeManager = get_node_or_null("SkillTreeManager") as SkillTreeManager
@@ -155,6 +156,13 @@ var _counter_measures_pending: Dictionary = {} # {base_ap:int, base_dice:int, bo
 
 var black_turn_index: int = 0
 var _ai_running: bool = false
+
+const BOARD_BASE_SIZE := Vector2(1294.0, 1004.0)
+const BOARD_MIN_SCALE := 0.60
+const BOARD_TOP_MARGIN := 24.0
+const BOARD_SIDE_MARGIN := 24.0
+const HAND_HUD_HEIGHT := 250.0
+const BOARD_GAP_TO_HAND := 20.0
 
 @onready var ai: AIController = get_node_or_null("AIController")
 
@@ -1051,6 +1059,41 @@ func _ready() -> void:
 		skill_overlay.buy_extra_pick_requested.connect(_on_skill_tree_buy_extra_pick)
 		skill_overlay.confirmed.connect(_on_skill_tree_overlay_confirmed)
 		skill_overlay.skipped.connect(_on_skill_tree_overlay_skipped)
+
+	get_viewport().size_changed.connect(_apply_hud_layout)
+	_apply_hud_layout()
+
+func _apply_hud_layout() -> void:
+	var viewport_size: Vector2 = get_viewport().get_visible_rect().size
+
+	if hand_hud != null:
+		hand_hud.anchor_left = 0.0
+		hand_hud.anchor_top = 1.0
+		hand_hud.anchor_right = 1.0
+		hand_hud.anchor_bottom = 1.0
+		hand_hud.offset_left = 0.0
+		hand_hud.offset_top = -HAND_HUD_HEIGHT
+		hand_hud.offset_right = 0.0
+		hand_hud.offset_bottom = 0.0
+
+	if board == null or not (board is Node2D):
+		return
+
+	var available_width: float = maxf(1.0, viewport_size.x - (BOARD_SIDE_MARGIN * 2.0))
+	var available_height: float = maxf(
+		1.0,
+		viewport_size.y - HAND_HUD_HEIGHT - BOARD_TOP_MARGIN - BOARD_GAP_TO_HAND
+	)
+	var scale_to_fit: float = minf(available_width / BOARD_BASE_SIZE.x, available_height / BOARD_BASE_SIZE.y)
+	var final_scale: float = maxf(BOARD_MIN_SCALE, scale_to_fit)
+
+	var board_node := board as Node2D
+	board_node.scale = Vector2.ONE * final_scale
+
+	var board_size: Vector2 = BOARD_BASE_SIZE * final_scale
+	var board_x: float = (viewport_size.x - board_size.x) * 0.5
+	var board_y: float = BOARD_TOP_MARGIN + ((available_height - board_size.y) * 0.5)
+	board_node.position = Vector2(board_x, board_y)
 
 # Called by RunController each round
 func start_round(rs: RunState) -> void:


### PR DESCRIPTION
### Motivation
- Move card slots from a vertical right rail to a centered horizontal bar beneath the game board so hand cards are displayed side-by-side. 
- Expose a fifth hand slot in gameplay so the player has five card slots available. 
- Prevent visual overlap by ensuring the board is centered and scales proportionally to the viewport while reserving space for the hand HUD.

### Description
- Updated `Scenes/main/RoundScene.tscn` to relocate the `HandHUD` to the bottom of the screen, change its `Panel` layout, and increase `custom_minimum_size` for bottom presentation. 
- Converted the card list from a `VBoxContainer` to an `HBoxContainer` and reduced item `separation` so cards render horizontally in a row (`CardList` now uses `HBoxContainer`). 
- Increased the round override `hand_size` from `4` to `5` so a fifth slot is populated at runtime. 
- Added responsive layout logic to `Scripts/game/RoundController.gd`: introduced `hand_hud` onready binding, board layout constants (`BOARD_BASE_SIZE`, `HAND_HUD_HEIGHT`, etc.), connected `get_viewport().size_changed` and implemented `_apply_hud_layout()` to reserve bottom space for the hand HUD, center the board, and compute a proportional `board.scale` to avoid overlap with the hand.

### Testing
- Ran scene/script inspections with `rg`/`sed`/`nl` to verify the `HandHUD` anchor/offset changes, `CardList` container type, `hand_size` update, and new `_apply_hud_layout` function; these checks succeeded. 
- Executed `git status`/`git diff` to confirm file deltas; these commands succeeded. 
- Attempted `godot --version` to perform a runtime check but it failed because the Godot binary is not available in this environment, so runtime validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dda6349dc832ebef75406359e55d4)